### PR TITLE
Improve handling of error responses from Forge API

### DIFF
--- a/lib/puppet_forge/v3/base.rb
+++ b/lib/puppet_forge/v3/base.rb
@@ -69,8 +69,8 @@ module PuppetForge
         # @param parsed_data [Hash<(:data, :errors)>] the parsed response data
         # @return [PaginatedCollection] the collection
         def new_collection(parsed_data)
-          col = super :data =>     parsed_data[:data][:results],
-                      :metadata => parsed_data[:data][:pagination],
+          col = super :data =>     parsed_data[:data][:results] || [],
+                      :metadata => parsed_data[:data][:pagination] || { limit: 10, total: 0, offset: 0 },
                       :errors =>   parsed_data[:errors]
 
           PaginatedCollection.new(self, col.to_a, col.metadata, col.errors)

--- a/spec/unit/forge/v3/base_spec.rb
+++ b/spec/unit/forge/v3/base_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe PuppetForge::V3::Base do
+  describe '::new_collection' do
+    it 'should handle responses with no results' do
+      response_data = { data: {}, errors: "Something bad happened!" }
+
+      PuppetForge::V3::Base.new_collection(response_data).should == []
+    end
+
+    it 'should handle responses with no pagination info' do
+      response_data = { data: {}, errors: "Something bad happened!" }
+
+      collection = PuppetForge::V3::Base.new_collection(response_data)
+
+      collection.limit.should == 10
+      collection.offset.should == 0
+      collection.total.should == 0
+    end
+  end
+end


### PR DESCRIPTION
Ensure that PaginatedCollection doesn't break when it receives a response without results and/or pagination info.
