### PR TITLE
Remove "require 'bundler/setup'"

### DIFF
--- a/lib/puppet_forge.rb
+++ b/lib/puppet_forge.rb
@@ -1,9 +1,3 @@
-begin
-  Gem::Specification.find_by_name('bundler', '~> 1.6')
-  require 'bundler/setup'
-rescue Gem::LoadError
-end
-
 require 'puppet_forge/version'
 
 module PuppetForge


### PR DESCRIPTION
This causes problems for applications that use puppet_forge as
libraries, for example librarian-puppet, as seen in the second error
message on
https://github.com/rodjek/librarian-puppet/issues/249

If librarian-puppet is installed via gem, but puppet_forge is not
included in the Gemfile that belongs to the current working directory,
the following error will occur:

.../gems/puppet_forge-1.0.2/lib/puppet_forge.rb:7:in `require':
        cannot load such file -- puppet_forge/version (LoadError)

This is caused by requiring 'bundler/setup', which limits $LOAD_PATH
to gems included in the current bundle, thus removing puppet_forge's
own gem path from $LOAD_PATH.
