### PR TITLE
retry requests to puppet API

### DIFF
--- a/lib/puppet_forge/v3/base.rb
+++ b/lib/puppet_forge/v3/base.rb
@@ -30,6 +30,7 @@ module PuppetForge
 
         Her::API.new :url => "#{PuppetForge.host}/v3/" do |c|
           c.use PuppetForge::Middleware::JSONForHer
+          c.use Faraday::Request::Retry
           c.use adapter
         end
       end


### PR DESCRIPTION
This appears to have fixed a problem with librarian-puppet for me. It was failing due to intermittent timeouts to the puppet forge, and adding this retry logic fixed it. Feel free to suggest changes or just pull this guy in.