### PR TITLE
(CODEMGMT-279) Specify versions for Her and Rspec.

### DIFF
--- a/puppet_forge.gemspec
+++ b/puppet_forge.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_runtime_dependency "her", "~> 0.6"
+  spec.add_runtime_dependency "her", "~> 0.6.8"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "cane"
   spec.add_development_dependency "yard"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,7 +48,6 @@ module StubbingHer
 end
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 

--- a/spec/unit/forge/v3/base_spec.rb
+++ b/spec/unit/forge/v3/base_spec.rb
@@ -5,7 +5,7 @@ describe PuppetForge::V3::Base do
     it 'should handle responses with no results' do
       response_data = { data: {}, errors: "Something bad happened!" }
 
-      PuppetForge::V3::Base.new_collection(response_data).should == []
+      expect(PuppetForge::V3::Base.new_collection(response_data)).to eq([])
     end
 
     it 'should handle responses with no pagination info' do
@@ -13,9 +13,9 @@ describe PuppetForge::V3::Base do
 
       collection = PuppetForge::V3::Base.new_collection(response_data)
 
-      collection.limit.should == 10
-      collection.offset.should == 0
-      collection.total.should == 0
+      expect(collection.limit).to eq(10)
+      expect(collection.offset).to eq(0)
+      expect(collection.total).to eq(0)
     end
   end
 end

--- a/spec/unit/forge/v3/module_spec.rb
+++ b/spec/unit/forge/v3/module_spec.rb
@@ -13,11 +13,11 @@ describe PuppetForge::V3::Module do
     let(:missing_mod) { PuppetForge::V3::Module.find('absent-apache') }
 
     it 'can find modules that exist' do
-      mod.name.should == 'apache'
+      expect(mod.name).to eq('apache')
     end
 
     it 'returns nil for non-existent modules' do
-      missing_mod.should be_nil
+      expect(missing_mod).to be_nil
     end
   end
 
@@ -35,12 +35,12 @@ describe PuppetForge::V3::Module do
     end
 
     it 'grants access to module attributes without an API call' do
-      PuppetForge::V3::User.should_not_receive(:request)
+      expect(PuppetForge::V3::User).not_to receive(:request)
       expect(mod.owner.username).to eql('puppetlabs')
     end
 
     it 'transparently makes API calls for other attributes' do
-      PuppetForge::V3::User.should_receive(:request).once.and_call_original
+      expect(PuppetForge::V3::User).to receive(:request).once.and_call_original
       expect(mod.owner.created_at).to_not be nil
     end
   end
@@ -53,7 +53,7 @@ describe PuppetForge::V3::Module do
     end
 
     it 'grants access to release attributes without an API call' do
-      PuppetForge::V3::Release.should_not_receive(:request)
+      expect(PuppetForge::V3::Release).not_to receive(:request)
       expect(mod.current_release.version).to_not be nil
     end
 
@@ -92,7 +92,7 @@ describe PuppetForge::V3::Module do
     end
 
     it 'grants access to release attributes without an API call' do
-      PuppetForge::V3::Release.should_not_receive(:request)
+      expect(PuppetForge::V3::Release).not_to receive(:request)
       expect(mod.releases.map(&:version)).to_not include nil
     end
 
@@ -100,7 +100,7 @@ describe PuppetForge::V3::Module do
       versions = %w[ 0.0.1 0.0.2 0.0.3 0.0.4 0.1.1 ]
       releases = mod.releases.select { |x| versions.include? x.version }
 
-      PuppetForge::V3::Release.should_receive(:request) \
+      expect(PuppetForge::V3::Release).to receive(:request) \
                         .exactly(5).times \
                         .and_call_original
 

--- a/spec/unit/forge/v3/release_spec.rb
+++ b/spec/unit/forge/v3/release_spec.rb
@@ -36,12 +36,12 @@ describe PuppetForge::V3::Release do
     end
 
     it 'grants access to module attributes without an API call' do
-      PuppetForge::V3::Module.should_not_receive(:request)
+      expect(PuppetForge::V3::Module).not_to receive(:request)
       expect(release.module.name).to eql('apache')
     end
 
     it 'transparently makes API calls for other attributes' do
-      PuppetForge::V3::Module.should_receive(:request).once.and_call_original
+      expect(PuppetForge::V3::Module).to receive(:request).once.and_call_original
       expect(release.module.created_at).to_not be nil
     end
   end

--- a/spec/unit/forge/v3/user_spec.rb
+++ b/spec/unit/forge/v3/user_spec.rb
@@ -13,11 +13,11 @@ describe PuppetForge::V3::User do
     let(:missing_user) { PuppetForge::V3::User.find('absent') }
 
     it 'can find users that exist' do
-      user.username.should == 'puppetlabs'
+      expect(user.username).to eq('puppetlabs')
     end
 
     it 'returns nil for non-existent users' do
-      missing_user.should be_nil
+      expect(missing_user).to be_nil
     end
   end
 

--- a/spec/unit/her/lazy_accessors_spec.rb
+++ b/spec/unit/her/lazy_accessors_spec.rb
@@ -39,12 +39,12 @@ describe Her::LazyAccessors do
   subject { klass.new(local_data) }
 
   it 'does not call methods to #inspect' do
-    subject.should_not_receive(:shadow)
+    expect(subject).not_to receive(:shadow)
     subject.inspect
   end
 
   describe 'local attributes' do
-    before { klass.should_not_receive(:request) }
+    before { expect(klass).not_to receive(:request) }
 
     example 'allow access to local attributes' do
       expect(subject.local).to eql('data')
@@ -101,7 +101,7 @@ describe Her::LazyAccessors do
     end
 
     example 'allow multiple instances to access remote attributes' do
-      klass.should_receive(:request).exactly(9).times.and_call_original
+      expect(klass).to receive(:request).exactly(9).times.and_call_original
       9.times { expect(klass.new(local_data).remote).to eql('DATA') }
     end
 

--- a/spec/unit/her/lazy_relations_spec.rb
+++ b/spec/unit/her/lazy_relations_spec.rb
@@ -59,12 +59,12 @@ describe Her::LazyRelations do
     it { should be_a(related_class) }
 
     it 'does not call methods to #inspect' do
-      subject.should_not_receive(:shadow)
+      expect(subject).not_to receive(:shadow)
       subject.inspect
     end
 
     describe 'local attributes' do
-      before { related_class.should_not_receive(:request) }
+      before { expect(related_class).not_to receive(:request) }
 
       example 'allow access to local attributes' do
         expect(subject.local).to eql('data')
@@ -115,7 +115,7 @@ describe Her::LazyRelations do
       end
 
       example 'allow multiple instances to access remote attributes' do
-        related_class.should_receive(:request) \
+        expect(related_class).to receive(:request) \
                      .exactly(9).times \
                      .and_call_original
 
@@ -186,12 +186,12 @@ describe Her::LazyRelations do
     it { should be_a(related_class) }
 
     it 'does not call methods to #inspect' do
-      subject.should_not_receive(:shadow)
+      expect(subject).not_to receive(:shadow)
       subject.inspect
     end
 
     describe 'local attributes' do
-      before { related_class.should_not_receive(:request) }
+      before { expect(related_class).not_to receive(:request) }
 
       example 'allow access to local attributes' do
         expect(subject.local).to eql('data')
@@ -242,7 +242,7 @@ describe Her::LazyRelations do
       end
 
       example 'allow multiple instances to access remote attributes' do
-        related_class.should_receive(:request) \
+        expect(related_class).to receive(:request) \
                      .exactly(9).times \
                      .and_call_original
 


### PR DESCRIPTION
Before this commit, if a user got a newer version of Her it could cause
Rspec tests to fail. With this commit, users are required to use the
version of Her that works with the module.

The commit also updated the Rspec tests to work with Rspec 3.x and
specifies this requirement in the gemspec.