### PR TITLE
(CODEMGMT-296) Add PaginatedCollection ORM for where request

### DIFF
--- a/lib/puppet_forge/v3/base.rb
+++ b/lib/puppet_forge/v3/base.rb
@@ -111,8 +111,11 @@ module PuppetForge
 
         # @private
         def new_collection(faraday_resp)
-          return PaginatedCollection.new(self) unless faraday_resp[:errors].nil?
-          PaginatedCollection.new(self, faraday_resp.body['results'], faraday_resp.body['pagination'], nil)
+          if faraday_resp[:errors].nil?
+            PaginatedCollection.new(self, faraday_resp.body['results'], faraday_resp.body['pagination'], nil)
+          else
+            PaginatedCollection.new(self)
+          end
         end
       end
     end

--- a/lib/puppet_forge/v3/base.rb
+++ b/lib/puppet_forge/v3/base.rb
@@ -38,7 +38,7 @@ module PuppetForge
               adapter = Faraday.default_adapter
             end
 
-            @faraday_api = Faraday.new :url => "#{PuppetForge.host}/" do |c|
+            @faraday_api = Faraday.new :url => "#{PuppetForge.host}" do |c|
               c.response :json, :content_type => 'application/json'
               c.adapter adapter
             end
@@ -50,7 +50,7 @@ module PuppetForge
         # @private
         def request(resource, item = nil, params = {})
           unless faraday_api.url_prefix =~ /^#{PuppetForge.host}/
-            faraday_api.url_prefix = "#{PuppetForge.host}/"
+            faraday_api.url_prefix = "#{PuppetForge.host}"
           end
 
           faraday_api.headers["User-Agent"] = %W[
@@ -61,9 +61,9 @@ module PuppetForge
           ].join(' ').strip
 
           if item.nil?
-            uri_path = "v3/#{resource}"
+            uri_path = "/v3/#{resource}"
           else
-            uri_path = "v3/#{resource}/#{item}"
+            uri_path = "/v3/#{resource}/#{item}"
           end
 
           faraday_api.get uri_path, params
@@ -82,7 +82,37 @@ module PuppetForge
         end
 
         def where(params)
-          request("#{self.name.split("::").last.downcase}s", nil, params)
+          resp = request("#{self.name.split("::").last.downcase}s", nil, params)
+
+          new_collection(resp)
+        end
+
+        def get_collection(uri_path)
+          resource, params = split_uri_path uri_path
+          resp = request(resource, nil, params)
+
+          new_collection(resp)
+        end
+
+        # @private
+        def split_uri_path(uri_path)
+          all, resource, params = /(?:\/v3\/)([^\/]+)(?:\?)(.*)/.match(uri_path).to_a
+
+          params = params.split('&')
+
+          param_hash = Hash.new
+          params.each do |param|
+            key, val = param.split('=')
+            param_hash[key] = val
+          end
+
+          [resource, param_hash]
+        end
+
+        # @private
+        def new_collection(faraday_resp)
+          return PaginatedCollection.new(self) unless faraday_resp[:errors].nil?
+          PaginatedCollection.new(self, faraday_resp.body['results'], faraday_resp.body['pagination'], nil)
         end
       end
     end

--- a/lib/puppet_forge/v3/base/paginated_collection.rb
+++ b/lib/puppet_forge/v3/base/paginated_collection.rb
@@ -5,23 +5,21 @@ module PuppetForge
       # Enables navigation of the Forge API's paginated datasets.
       class PaginatedCollection < Array
 
+        LIMIT = 10
+
         # @api private
         # @param klass [PuppetForge::V3::Base] the class to page over
         # @param data [Array] the current data page
         # @param metadata [Hash<(:limit, :total, :offset)>] page metadata
         # @param errors [Object] errors for the page request
-        def initialize(klass, data = [], metadata = {'total' => 0, 'offset' => 0, 'limit' => 10}, errors = nil)
+        def initialize(klass, data = [], metadata = {'total' => 0, 'offset' => 0, 'limit' => LIMIT}, errors = nil)
           super()
           @metadata = metadata
           @errors = errors
           @klass = klass
 
           data.each do |item|
-            if item.is_a? Hash
-              self << @klass.new(item)
-            else
-              self << item
-            end
+            self << @klass.new(item)
           end
         end
 

--- a/lib/puppet_forge/v3/base/paginated_collection.rb
+++ b/lib/puppet_forge/v3/base/paginated_collection.rb
@@ -10,13 +10,18 @@ module PuppetForge
         # @param data [Array] the current data page
         # @param metadata [Hash<(:limit, :total, :offset)>] page metadata
         # @param errors [Object] errors for the page request
-        def initialize(klass, data, metadata, errors)
+        def initialize(klass, data = [], metadata = {'total' => 0, 'offset' => 0, 'limit' => 10}, errors = nil)
+          super()
           @metadata = metadata
           @errors = errors
           @klass = klass
 
           data.each do |item|
-            self << @klass.new(item)
+            if item.is_a? Hash
+              self << @klass.new(item)
+            else
+              self << item
+            end
           end
         end
 

--- a/lib/puppet_forge/v3/base/paginated_collection.rb
+++ b/lib/puppet_forge/v3/base/paginated_collection.rb
@@ -5,7 +5,8 @@ module PuppetForge
       # Enables navigation of the Forge API's paginated datasets.
       class PaginatedCollection < Array
 
-        LIMIT = 10
+        # Default pagination limit for API request
+        LIMIT = 20
 
         # @api private
         # @param klass [PuppetForge::V3::Base] the class to page over

--- a/spec/integration/forge/v3/module_spec.rb
+++ b/spec/integration/forge/v3/module_spec.rb
@@ -20,18 +20,15 @@ describe PuppetForge::V3::Module do
 
   end
 
-  context "#find" do
-    context "when the user exists," do
+  context "::find" do
+    context "when the user exists" do
+      let (:mod) { PuppetForge::V3::Module.find('puppetforgegemtesting-thorin') }
 
-      it "find returns a PuppetForge::V3::Module." do
-        mod = PuppetForge::V3::Module.find('puppetforgegemtesting-thorin')
-
+      it "returns a PuppetForge::V3::Module." do
         expect(mod).to be_a(PuppetForge::V3::Module)
       end
 
-      it "it exposes the API information." do
-        mod = PuppetForge::V3::Module.find('puppetforgegemtesting-thorin')
-
+      it "exposes the API information." do
         expect(mod).to respond_to(:uri)
         expect(mod).to respond_to(:owner)
         expect(mod).to respond_to(:current_release)
@@ -45,7 +42,8 @@ describe PuppetForge::V3::Module do
 
     end
 
-    context "when the module doesn't exist," do
+    context "when the module doesn't exist" do
+      let (:mod) { PuppetForge::V3::Module.find('puppetforgegemtesting-thorin') }
 
       it "find returns nil." do
         mod = PuppetForge::V3::Module.find('puppetforgegemtesting-bilbo')
@@ -55,6 +53,42 @@ describe PuppetForge::V3::Module do
 
     end
 
+  end
+
+  context "::where" do
+    context "finds matching resources" do
+
+      it "only returns modules that match the query" do
+        modules = PuppetForge::V3::Module.where(:owner => 'puppetforgegemtesting')
+
+        expect(modules).to be_a(PuppetForge::V3::Base::PaginatedCollection)
+        modules.each do |mod|
+          expect(mod.owner.username).to eq('puppetforgegemtesting')
+        end
+
+      end
+
+      it "returns a paginated response" do
+        modules = PuppetForge::V3::Module.where(:owner => 'puppetforgegemtesting', :limit => 1)
+
+        expect(modules.limit).to eq(1)
+        expect(modules.total).to eq(2)
+
+        expect(modules.next).not_to be_nil
+      end
+
+    end
+
+    context "does not find matching resources" do
+      it "returns an empty PaginatedCollection" do
+        modules = PuppetForge::V3::Module.where(:owner => 'absentuser')
+
+        expect(modules).to be_a(PuppetForge::V3::Base::PaginatedCollection)
+
+        expect(modules.size).to eq(0)
+        expect(modules.empty?).to be(true)
+      end
+    end
   end
 end
 

--- a/spec/integration/forge/v3/release_spec.rb
+++ b/spec/integration/forge/v3/release_spec.rb
@@ -65,24 +65,24 @@ describe PuppetForge::V3::Release do
       end
 
       it "returns a paginated response" do
-        modules = PuppetForge::V3::Release.where(:module => 'puppetforgegemtesting-thorin', :limit => 1)
+        releases = PuppetForge::V3::Release.where(:module => 'puppetforgegemtesting-thorin', :limit => 1)
 
-        expect(modules.limit).to eq(1)
-        expect(modules.total).to eq(2)
+        expect(releases.limit).to eq(1)
+        expect(releases.total).to eq(2)
 
-        expect(modules.next).not_to be_nil
+        expect(releases.next).not_to be_nil
       end
 
     end
 
     context "does not find matching resources" do
       it "returns an empty PaginatedCollection" do
-        modules = PuppetForge::V3::Release.where(:module => 'puppetforgegemtesting-notamodule')
+        releases = PuppetForge::V3::Release.where(:module => 'puppetforgegemtesting-notamodule')
 
-        expect(modules).to be_a(PuppetForge::V3::Base::PaginatedCollection)
+        expect(releases).to be_a(PuppetForge::V3::Base::PaginatedCollection)
 
-        expect(modules.size).to eq(0)
-        expect(modules.empty?).to be(true)
+        expect(releases.size).to eq(0)
+        expect(releases.empty?).to be(true)
       end
     end
   end

--- a/spec/integration/forge/v3/release_spec.rb
+++ b/spec/integration/forge/v3/release_spec.rb
@@ -50,5 +50,41 @@ describe PuppetForge::V3::Release do
     end
 
   end
+
+  context "::where" do
+    context "finds matching resources" do
+
+      it "only returns releases that match the query" do
+        releases = PuppetForge::V3::Release.where(:module => 'puppetforgegemtesting-thorin')
+
+        expect(releases).to be_a(PuppetForge::V3::Base::PaginatedCollection)
+
+        expect(releases.first.version).to eq("0.0.2")
+        expect(releases[1].version).to eq("0.0.1")
+
+      end
+
+      it "returns a paginated response" do
+        modules = PuppetForge::V3::Release.where(:module => 'puppetforgegemtesting-thorin', :limit => 1)
+
+        expect(modules.limit).to eq(1)
+        expect(modules.total).to eq(2)
+
+        expect(modules.next).not_to be_nil
+      end
+
+    end
+
+    context "does not find matching resources" do
+      it "returns an empty PaginatedCollection" do
+        modules = PuppetForge::V3::Release.where(:module => 'puppetforgegemtesting-notamodule')
+
+        expect(modules).to be_a(PuppetForge::V3::Base::PaginatedCollection)
+
+        expect(modules.size).to eq(0)
+        expect(modules.empty?).to be(true)
+      end
+    end
+  end
 end
 

--- a/spec/integration/forge/v3/user_spec.rb
+++ b/spec/integration/forge/v3/user_spec.rb
@@ -39,7 +39,7 @@ describe PuppetForge::V3::User do
       end
 
     end
-    
+
     context "when the user doesn't exists," do
 
       it "find returns nil." do
@@ -48,6 +48,37 @@ describe PuppetForge::V3::User do
       end
 
     end
+  end
+
+  context "::where" do
+    context "finds matching resources" do
+
+      it "returns sorted users" do
+        users = PuppetForge::V3::User.where(:sort_by => 'releases')
+
+        expect(users).to be_a(PuppetForge::V3::Base::PaginatedCollection)
+
+        previous_releases = users.first.release_count
+        users.each do |user|
+          expect(user.release_count).to be <= previous_releases
+          previous_releases = user.release_count
+        end
+
+      end
+
+      it "returns a paginated response" do
+        modules = PuppetForge::V3::User.where(:user => 'puppetforgegemtesting', :limit => 1)
+
+        expect(modules.limit).to eq(1)
+
+        2.times do
+          expect(modules).not_to be_nil
+          modules = modules.next
+        end
+      end
+
+    end
+
   end
 end
 

--- a/spec/integration/forge/v3/user_spec.rb
+++ b/spec/integration/forge/v3/user_spec.rb
@@ -67,13 +67,13 @@ describe PuppetForge::V3::User do
       end
 
       it "returns a paginated response" do
-        modules = PuppetForge::V3::User.where(:user => 'puppetforgegemtesting', :limit => 1)
+        users = PuppetForge::V3::User.where(:limit => 1)
 
-        expect(modules.limit).to eq(1)
+        expect(users.limit).to eq(1)
 
         2.times do
-          expect(modules).not_to be_nil
-          modules = modules.next
+          expect(users).not_to be_nil
+          users = users.next
         end
       end
 

--- a/spec/unit/forge/v3/base/paginated_collection_spec.rb
+++ b/spec/unit/forge/v3/base/paginated_collection_spec.rb
@@ -2,47 +2,47 @@ require 'spec_helper'
 
 describe PuppetForge::V3::Base::PaginatedCollection do
   let(:klass) do
-    Class.new do
-      def self.get_collection(url)
-        data = {
-          '/v3/collection'        => [ :A, :B, :C ],
-          '/v3/collection?page=2' => [ :D, :E, :F ],
-          '/v3/collection?page=3' => [ :G, :H ],
-        }
+    allow(PuppetForge::V3::Base).to receive(:get_collection) do |url|
+      data = {
+        '/v3/collection'        => [ :A, :B, :C ],
+        '/v3/collection?page=2' => [ :D, :E, :F ],
+        '/v3/collection?page=3' => [ :G, :H ],
+      }
 
-        meta = {
-          '/v3/collection' => {
-            :limit    => 3,
-            :offset   => 0,
-            :first    => '/v3/collection',
-            :previous => nil,
-            :current  => '/v3/collection',
-            :next     => '/v3/collection?page=2',
-            :total    => 8,
-          },
-          '/v3/collection?page=2' => {
-            :limit    => 3,
-            :offset   => 0,
-            :first    => '/v3/collection',
-            :previous => '/v3/collection',
-            :current  => '/v3/collection?page=2',
-            :next     => '/v3/collection?page=3',
-            :total    => 8,
-          },
-          '/v3/collection?page=3' => {
-            :limit    => 3,
-            :offset   => 0,
-            :first    => '/v3/collection',
-            :previous => '/v3/collection?page=2',
-            :current  => '/v3/collection?page=3',
-            :next     => nil,
-            :total    => 8,
-          },
-        }
+      meta = {
+        '/v3/collection' => {
+          'limit'    => 3,
+          'offset'   => 0,
+          'first'    => '/v3/collection',
+          'previous' => nil,
+          'current'  => '/v3/collection',
+          'next'     => '/v3/collection?page=2',
+          'total'    => 8,
+        },
+        '/v3/collection?page=2' => {
+          'limit'    => 3,
+          'offset'   => 0,
+          'first'    => '/v3/collection',
+          'previous' => '/v3/collection',
+          'current'  => '/v3/collection?page=2',
+          'next'     => '/v3/collection?page=3',
+          'total'    => 8,
+        },
+        '/v3/collection?page=3' => {
+          'limit'    => 3,
+          'offset'   => 0,
+          'first'    => '/v3/collection',
+          'previous' => '/v3/collection?page=2',
+          'current'  => '/v3/collection?page=3',
+          'next'     => nil,
+          'total'    => 8,
+        },
+      }
 
-        PuppetForge::V3::Base::PaginatedCollection.new(self, data[url], meta[url], {})
-      end
+      PuppetForge::V3::Base::PaginatedCollection.new(PuppetForge::V3::Base, data[url], meta[url], {})
     end
+
+    PuppetForge::V3::Base
   end
 
   subject { klass.get_collection('/v3/collection') }
@@ -66,7 +66,7 @@ describe PuppetForge::V3::Base::PaginatedCollection do
   end
 
   it 'exposes the pagination metadata' do
-    expect(subject.metadata[:limit]).to be subject.size
+    expect(subject.limit).to be subject.size
   end
 
   it 'exposes previous_url and next_url' do

--- a/spec/unit/forge/v3/base_spec.rb
+++ b/spec/unit/forge/v3/base_spec.rb
@@ -13,7 +13,7 @@ describe PuppetForge::V3::Base do
 
       collection = PuppetForge::V3::Base.new_collection(response_data)
 
-      expect(collection.limit).to eq(10)
+      expect(collection.limit).to eq(20)
       expect(collection.offset).to eq(0)
       expect(collection.total).to eq(0)
     end

--- a/spec/unit/forge/v3/module_spec.rb
+++ b/spec/unit/forge/v3/module_spec.rb
@@ -89,9 +89,7 @@ describe PuppetForge::V3::Module do
     it 'loads releases lazily' do
       versions = %w[ 0.0.1 0.0.2 0.0.3 0.0.4 0.1.1 ]
 
-      expect(PuppetForge::V3::Release).to receive(:find) \
-                        .exactly(5).times \
-                        .and_call_original
+      expect(PuppetForge::V3::Release).to receive(:find).exactly(5).times.and_call_original
 
       releases = mod.releases
 

--- a/spec/unit/forge/v3/module_spec.rb
+++ b/spec/unit/forge/v3/module_spec.rb
@@ -40,7 +40,7 @@ describe PuppetForge::V3::Module do
     end
 
     it 'transparently makes API calls for other attributes' do
-      expect(PuppetForge::V3::User).to receive(:request).once
+      expect(PuppetForge::V3::User).to receive(:request).once.and_call_original
       expect(mod.owner.created_at).to_not be nil
     end
   end
@@ -57,16 +57,6 @@ describe PuppetForge::V3::Module do
       expect(mod.current_release.version).to_not be nil
     end
 
-    it 'transparently makes API calls for other attributes' do
-      stub_api_for(PuppetForge::V3::Release) do |stubs|
-        stubs.get(mod.current_release.uri) do
-          load_fixture('/v3/releases/puppetlabs-apache-0.0.1')
-        end
-      end
-
-      mod.attributes[:current_release].delete :created_at
-      expect(mod.current_release.created_at).to_not be nil
-    end
   end
 
   describe '#releases' do
@@ -96,14 +86,22 @@ describe PuppetForge::V3::Module do
       expect(mod.releases.map(&:version)).to_not include nil
     end
 
-    it 'transparently makes API calls for other attributes' do
+    it 'loads releases lazily' do
       versions = %w[ 0.0.1 0.0.2 0.0.3 0.0.4 0.1.1 ]
-      releases = mod.releases.select { |x| versions.include? x.version }
 
-      expect(PuppetForge::V3::Release).to receive(:request) \
-                        .exactly(5).times
+      expect(PuppetForge::V3::Release).to receive(:find) \
+                        .exactly(5).times \
+                        .and_call_original
+
+      releases = mod.releases
 
       expect(releases.map(&:created_at)).to_not include nil
+    end
+
+    it 'transparently makes API calls for other attributes' do
+      expect(PuppetForge::V3::Release).to receive(:where) \
+                        .once.and_call_original
+      releases = mod.releases
     end
   end
 

--- a/spec/unit/forge/v3/release_spec.rb
+++ b/spec/unit/forge/v3/release_spec.rb
@@ -93,6 +93,11 @@ describe PuppetForge::V3::Release do
       stub_api_for(PuppetForge::V3::Module) do |stubs|
         stub_fixture(stubs, :get, '/v3/modules/puppetlabs-apache')
       end
+
+      stub_api_for(PuppetForge::V3::Release) do |stubs|
+        stub_fixture(stubs, :get, '/v3/releases/puppetlabs-apache-0.0.1')
+        stub_fixture(stubs, :get, '/v3/releases?module=puppetlabs-apache')
+      end
     end
 
     it 'is lazy and repeatable' do


### PR DESCRIPTION
There should be 55 RSpec tests with 6 failures. 

* 4 failures are because the requests are not made lazily.
* 1 failure is because we have not added downloading back into the gem after removing Her.
* 1 is because the PMT Acceptance Forge is running on old API code.