### PR TITLE
(CODEMGMT-297) Integrate ModuleRelease from r10k

### DIFF
--- a/lib/puppet_forge.rb
+++ b/lib/puppet_forge.rb
@@ -8,7 +8,11 @@ module PuppetForge
 
   self.host = 'https://forgeapi.puppetlabs.com'
 
+  require 'puppet_forge/tar'
+  require 'puppet_forge/unpacker'
   require 'puppet_forge/v3'
+
+  const_set :Metadata, PuppetForge::V3::Metadata
 
   const_set :User, PuppetForge::V3::User
   const_set :Module, PuppetForge::V3::Module

--- a/lib/puppet_forge/connection.rb
+++ b/lib/puppet_forge/connection.rb
@@ -1,0 +1,77 @@
+require 'puppet_forge/connection/connection_failure'
+
+require 'faraday'
+require 'faraday_middleware'
+
+module PuppetForge
+  # Provide a common mixin for adding a HTTP connection to classes.
+  #
+  # This module provides a common method for creating HTTP connections as well
+  # as reusing a single connection object between multiple classes. Including
+  # classes can invoke #conn to get a reasonably configured HTTP connection.
+  # Connection objects can be passed with the #conn= method.
+  #
+  # @example
+  #   class HTTPThing
+  #     include PuppetForge::Connection
+  #   end
+  #   thing = HTTPThing.new
+  #   thing.conn = thing.make_connection('https://non-standard-forge.site')
+  #
+  # @api private
+  module Connection
+
+    attr_writer :conn
+
+    USER_AGENT = "#{PuppetForge.user_agent} PuppetForge.gem/#{PuppetForge::VERSION} Faraday/#{Faraday::VERSION} Ruby/#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL} (#{RUBY_PLATFORM})".strip
+
+    def self.authorization=(token)
+      @authorization = token
+    end
+
+    def self.authorization
+      @authorization
+    end
+
+    # @return [Faraday::Connection] An existing Faraday connection if one was
+    #   already set, otherwise a new Faraday connection.
+    def conn
+      @conn ||= default_connection
+    end
+
+    def default_connection
+
+      begin
+        # Use Typhoeus if available.
+        Gem::Specification.find_by_name('typhoeus', '~> 0.6')
+        require 'typhoeus/adapters/faraday'
+        adapter = Faraday::Adapter::Typhoeus
+      rescue Gem::LoadError
+        adapter = Faraday.default_adapter
+      end
+
+      make_connection('https://forgeapi.puppetlabs.com', [adapter])
+    end
+
+    # Generate a new Faraday connection for the given URL.
+    #
+    # @param url [String] the base URL for this connection
+    # @return [Faraday::Connection]
+    def make_connection(url, adapter_args = nil, opts = {})
+      adapter_args ||= [Faraday.default_adapter]
+      options = { :headers => { :user_agent => USER_AGENT } }.merge(opts)
+
+      if token = PuppetForge::Connection.authorization
+        options[:headers][:authorization] = token
+      end
+
+      Faraday.new(url, options) do |builder|
+        builder.response(:json, :content_type => /\bjson$/)
+        builder.response(:raise_error)
+        builder.use(:connection_failure)
+
+        builder.adapter(*adapter_args)
+      end
+    end
+  end
+end

--- a/lib/puppet_forge/connection/connection_failure.rb
+++ b/lib/puppet_forge/connection/connection_failure.rb
@@ -1,0 +1,26 @@
+require 'faraday'
+
+module PuppetForge
+  module Connection
+    # Wrap Faraday connection failures to include the host and optional proxy
+    # in use for the failed connection.
+    class ConnectionFailure < Faraday::Middleware
+      def call(env)
+        @app.call(env)
+      rescue Faraday::ConnectionFailed => e
+        baseurl = env[:url].dup
+        baseurl.path = ''
+        errmsg = "Unable to connect to #{baseurl.to_s}"
+        if proxy = env[:request][:proxy]
+          errmsg << " (using proxy #{proxy.uri.to_s})"
+        end
+        errmsg << ": #{e.message}"
+        m = Faraday::ConnectionFailed.new(errmsg)
+        m.set_backtrace(e.backtrace)
+        raise m
+      end
+    end
+  end
+end
+
+Faraday::Middleware.register_middleware(:connection_failure => lambda { PuppetForge::Connection::ConnectionFailure })

--- a/lib/puppet_forge/error.rb
+++ b/lib/puppet_forge/error.rb
@@ -1,0 +1,34 @@
+module PuppetForge
+  class Error < RuntimeError
+    attr_accessor :original
+    def initialize(message, original=nil)
+      super(message)
+      @original = original
+    end
+  end
+
+  class ExecutionFailure < PuppetForge::Error
+  end
+
+  class InvalidPathInPackageError < PuppetForge::Error
+    def initialize(options)
+      @entry_path = options[:entry_path]
+      @directory  = options[:directory]
+      super "Attempt to install file into #{@entry_path.inspect} under #{@directory.inspect}"
+    end
+
+    def multiline
+      <<-MSG.strip
+Could not install package
+  Package attempted to install file into
+  #{@entry_path.inspect} under #{@directory.inspect}.
+      MSG
+    end
+  end
+
+  class ModuleNotFound < PuppetForge::Error
+  end
+
+  class ReleaseNotFound < PuppetForge::Error
+  end
+end

--- a/lib/puppet_forge/tar.rb
+++ b/lib/puppet_forge/tar.rb
@@ -1,0 +1,10 @@
+
+module PuppetForge
+  class Tar
+    require 'puppet_forge/tar/mini'
+
+    def self.instance
+      Mini.new
+    end
+  end
+end

--- a/lib/puppet_forge/tar/mini.rb
+++ b/lib/puppet_forge/tar/mini.rb
@@ -1,0 +1,81 @@
+require 'zlib'
+require 'archive/tar/minitar'
+
+module PuppetForge
+  class Tar
+    class Mini
+
+      SYMLINK_FLAGS = [2]
+      VALID_TAR_FLAGS = (0..7)
+
+      # @return [Hash{:symbol => Array<String>}] a hash with file-category keys pointing to lists of filenames.
+      def unpack(sourcefile, destdir)
+        # directories need to be changed outside of the Minitar::unpack because directories don't have a :file_done action
+        dirlist = []
+        file_lists = {}
+        Zlib::GzipReader.open(sourcefile) do |reader|
+          file_lists = validate_files(reader)
+          Archive::Tar::Minitar.unpack(reader, destdir, file_lists[:valid]) do |action, name, stats|
+            case action
+            when :file_done
+              FileUtils.chmod('u+rw,g+r,a-st', "#{destdir}/#{name}")
+            when :file_start
+              validate_entry(destdir, name)
+            when :dir
+              validate_entry(destdir, name)
+              dirlist << "#{destdir}/#{name}"
+            end
+          end
+        end
+        dirlist.each {|d| File.chmod(0755, d)}
+        file_lists
+      end
+
+      def pack(sourcedir, destfile)
+        Zlib::GzipWriter.open(destfile) do |writer|
+          Archive::Tar::Minitar.pack(sourcedir, writer)
+        end
+      end
+
+      private
+
+      # Categorize all the files in tarfile as :valid, :invalid, or :symlink.
+      #
+      # :invalid files include 'x' and 'g' flags from the PAX standard but and any other non-standard tar flags.
+      #   tar format info: http://pic.dhe.ibm.com/infocenter/zos/v1r13/index.jsp?topic=%2Fcom.ibm.zos.r13.bpxa500%2Ftaf.htm
+      #   pax format info: http://pic.dhe.ibm.com/infocenter/zos/v1r13/index.jsp?topic=%2Fcom.ibm.zos.r13.bpxa500%2Fpxarchfm.htm
+      # :symlinks are not supported in Puppet modules
+      # :valid files are any of those that can be used in modules
+      # @param tarfile name of the tarfile
+      # @return [Hash{:symbol => Array<String>}] a hash with file-category keys pointing to lists of filenames.
+      def validate_files(tarfile)
+        file_lists = {:valid => [], :invalid => [], :symlinks => []}
+        Archive::Tar::Minitar.open(tarfile).each do |entry|
+          flag = entry.typeflag
+          if flag.nil? || flag =~ /[[:digit:]]/ && SYMLINK_FLAGS.include?(flag.to_i)
+            file_lists[:symlinks] << entry.name
+          elsif flag.nil? || flag =~ /[[:digit:]]/ && VALID_TAR_FLAGS.include?(flag.to_i)
+            file_lists[:valid] << entry.name
+          else
+            file_lists[:invalid] << entry.name 
+          end
+        end
+        file_lists
+      end
+
+      def validate_entry(destdir, path)
+        if Pathname.new(path).absolute?
+          raise PuppetForge::InvalidPathInPackageError, :entry_path => path, :directory => destdir
+        end
+
+        path = File.expand_path File.join(destdir, path)
+
+        if path !~ /\A#{Regexp.escape destdir}/
+          raise PuppetForge::InvalidPathInPackageError, :entry_path => path, :directory => destdir
+        end
+      end
+    end
+  end
+
+end
+

--- a/lib/puppet_forge/unpacker.rb
+++ b/lib/puppet_forge/unpacker.rb
@@ -1,0 +1,68 @@
+require 'pathname'
+require 'puppet_forge/error'
+require 'puppet_forge/tar'
+
+module PuppetForge
+  class Unpacker
+    # Unpack a tar file into a specified directory
+    #
+    # @param filename [String] the file to unpack
+    # @param target [String] the target directory to unpack into
+    # @return [Hash{:symbol => Array<String>}] a hash with file-category keys pointing to lists of filenames.
+    #   The categories are :valid, :invalid and :symlink
+    def self.unpack(filename, target, tmpdir)
+      inst = self.new(filename, target, tmpdir)
+      file_lists = inst.unpack
+      inst.move_into(Pathname.new(target))
+      file_lists
+    end
+
+    # Set the owner/group of the target directory to those of the source
+    # Note: don't call this function on Microsoft Windows
+    #
+    # @param source [Pathname] source of the permissions
+    # @param target [Pathname] target of the permissions change
+    def self.harmonize_ownership(source, target)
+        FileUtils.chown_R(source.stat.uid, source.stat.gid, target)
+    end
+
+    # @param filename [String] the file to unpack
+    # @param target [String] the target directory to unpack into
+    def initialize(filename, target, tmpdir)
+      @filename = filename
+      @target = target
+      @tmpdir = tmpdir
+    end
+
+    # @api private
+    def unpack
+      begin
+        PuppetForge::Tar.instance.unpack(@filename, @tmpdir)
+      rescue PuppetForge::ExecutionFailure => e
+        raise RuntimeError, "Could not extract contents of module archive: #{e.message}"
+      end
+    end
+
+    # @api private
+    def move_into(dir)
+      dir.rmtree if dir.exist?
+      FileUtils.mv(root_dir, dir)
+    ensure
+      FileUtils.rmtree(@tmpdir)
+    end
+
+    # @api private
+    def root_dir
+      return @root_dir if @root_dir
+
+      # Grab the first directory containing a metadata.json file
+      metadata_file = Dir["#{@tmpdir}/**/metadata.json"].sort_by(&:length)[0]
+
+      if metadata_file
+        @root_dir = Pathname.new(metadata_file).dirname
+      else
+        raise "No valid metadata.json found!"
+      end
+    end
+  end
+end

--- a/lib/puppet_forge/v3.rb
+++ b/lib/puppet_forge/v3.rb
@@ -2,8 +2,19 @@ module PuppetForge
 
   # Models specific to the Puppet Forge's v3 API.
   module V3
+    # Normalize a module name to use a hyphen as the separator between the
+    # author and module.
+
+    # @example
+    #   PuppetForge::V3.normalize_name('my/module') #=> 'my-module'
+    #   PuppetForge::V3.normalize_name('my-module') #=> 'my-module'
+    def self.normalize_name(name)
+      name.tr('/', '-')
+    end
   end
 end
+
+require 'puppet_forge/v3/metadata'
 
 require 'puppet_forge/v3/user'
 require 'puppet_forge/v3/module'

--- a/lib/puppet_forge/v3/metadata.rb
+++ b/lib/puppet_forge/v3/metadata.rb
@@ -1,0 +1,197 @@
+require 'uri'
+require 'json'
+require 'set'
+require 'semantic_puppet/version'
+
+module PuppetForge
+  module V3
+    # This class provides a data structure representing a module's metadata.
+    # @api private
+    class Metadata
+
+      attr_accessor :module_name
+
+      DEFAULTS = {
+        'name'         => nil,
+        'version'      => nil,
+        'author'       => nil,
+        'summary'      => nil,
+        'license'      => 'Apache-2.0',
+        'source'       => '',
+        'project_page' => nil,
+        'issues_url'   => nil,
+        'dependencies' => Set.new.freeze,
+      }
+
+      def initialize
+        @data = DEFAULTS.dup
+        @data['dependencies'] = @data['dependencies'].dup
+      end
+
+      # Returns a filesystem-friendly version of this module name.
+      def dashed_name
+        PuppetForge::V3.normalize_name(@data['name']) if @data['name']
+      end
+
+      # Returns a string that uniquely represents this version of this module.
+      def release_name
+        return nil unless @data['name'] && @data['version']
+        [ dashed_name, @data['version'] ].join('-')
+      end
+
+      alias :name :module_name
+      alias :full_module_name :dashed_name
+
+      # Merges the current set of metadata with another metadata hash.  This
+      # method also handles the validation of module names and versions, in an
+      # effort to be proactive about module publishing constraints.
+      def update(data, with_dependencies = true)
+        process_name(data) if data['name']
+        process_version(data) if data['version']
+        process_source(data) if data['source']
+        merge_dependencies(data) if with_dependencies && data['dependencies']
+
+        @data.merge!(data)
+        return self
+      end
+
+      # Validates the name and version_requirement for a dependency, then creates
+      # the Dependency and adds it.
+      # Returns the Dependency that was added.
+      def add_dependency(name, version_requirement=nil, repository=nil)
+        validate_name(name)
+        validate_version_range(version_requirement) if version_requirement
+
+        if dup = @data['dependencies'].find { |d| d.full_module_name == name && d.version_requirement != version_requirement }
+          raise ArgumentError, "Dependency conflict for #{full_module_name}: Dependency #{name} was given conflicting version requirements #{version_requirement} and #{dup.version_requirement}. Verify that there are no duplicates in the metadata.json or the Modulefile."
+        end
+
+        dep = Dependency.new(name, version_requirement, repository)
+        @data['dependencies'].add(dep)
+
+        dep
+      end
+
+      # Provides an accessor for the now defunct 'description' property.  This
+      # addresses a regression in Puppet 3.6.x where previously valid templates
+      # refering to the 'description' property were broken.
+      # @deprecated
+      def description
+        @data['description']
+      end
+
+      def dependencies
+        @data['dependencies'].to_a
+      end
+
+      # Returns a hash of the module's metadata.  Used by Puppet's automated
+      # serialization routines.
+      #
+      # @see Puppet::Network::FormatSupport#to_data_hash
+      def to_hash
+        @data
+      end
+      alias :to_data_hash :to_hash
+
+      def to_json
+        data = @data.dup.merge('dependencies' => dependencies)
+
+        contents = data.keys.map do |k|
+          value = (JSON.pretty_generate(data[k]) rescue data[k].to_json)
+          "#{k.to_json}: #{value}"
+        end
+
+        "{\n" + contents.join(",\n").gsub(/^/, '  ') + "\n}\n"
+      end
+
+      # Expose any metadata keys as callable reader methods.
+      def method_missing(name, *args)
+        return @data[name.to_s] if @data.key? name.to_s
+        super
+      end
+
+      private
+
+      # Do basic validation and parsing of the name parameter.
+      def process_name(data)
+        validate_name(data['name'])
+        author, @module_name = data['name'].split(/[-\/]/, 2)
+
+        data['author'] ||= author if @data['author'] == DEFAULTS['author']
+      end
+
+      # Do basic validation on the version parameter.
+      def process_version(data)
+        validate_version(data['version'])
+      end
+
+      # Do basic parsing of the source parameter.  If the source is hosted on
+      # GitHub, we can predict sensible defaults for both project_page and
+      # issues_url.
+      def process_source(data)
+        if data['source'] =~ %r[://]
+          source_uri = URI.parse(data['source'])
+        else
+          source_uri = URI.parse("http://#{data['source']}")
+        end
+
+        if source_uri.host =~ /^(www\.)?github\.com$/
+          source_uri.scheme = 'https'
+          source_uri.path.sub!(/\.git$/, '')
+          data['project_page'] ||= @data['project_page'] || source_uri.to_s
+          data['issues_url'] ||= @data['issues_url'] || source_uri.to_s.sub(/\/*$/, '') + '/issues'
+        end
+
+      rescue URI::Error
+        return
+      end
+
+      # Validates and parses the dependencies.
+      def merge_dependencies(data)
+        data['dependencies'].each do |dep|
+          add_dependency(dep['name'], dep['version_requirement'], dep['repository'])
+        end
+
+        # Clear dependencies so @data dependencies are not overwritten
+        data.delete 'dependencies'
+      end
+
+      # Validates that the given module name is both namespaced and well-formed.
+      def validate_name(name)
+        return if name =~ /\A[a-z0-9]+[-\/][a-z][a-z0-9_]*\Z/i
+
+        namespace, modname = name.split(/[-\/]/, 2)
+        modname = :namespace_missing if namespace == ''
+
+        err = case modname
+        when nil, '', :namespace_missing
+          "the field must be a namespaced module name"
+        when /[^a-z0-9_]/i
+          "the module name contains non-alphanumeric (or underscore) characters"
+        when /^[^a-z]/i
+          "the module name must begin with a letter"
+        else
+          "the namespace contains non-alphanumeric characters"
+        end
+
+        raise ArgumentError, "Invalid 'name' field in metadata.json: #{err}"
+      end
+
+      # Validates that the version string can be parsed by SemanticPuppet.
+      def validate_version(version)
+        return if SemanticPuppet::Version.valid?(version)
+
+        err = "version string cannot be parsed as a valid Semantic Version"
+        raise ArgumentError, "Invalid 'version' field in metadata.json: #{err}"
+      end
+
+      # Validates that the version range can be parsed by SemanticPuppet.
+      def validate_version_range(version_range)
+        SemanticPuppet::VersionRange.parse(version_range)
+      rescue ArgumentError => e
+        raise ArgumentError, "Invalid 'version_range' field in metadata.json: #{e}"
+      end
+    end
+  end
+end
+

--- a/lib/puppet_forge/v3/release.rb
+++ b/lib/puppet_forge/v3/release.rb
@@ -31,15 +31,40 @@ module PuppetForge
 
       # Downloads the Release tarball to the specified file path.
       #
-      # @todo Stream the tarball data to disk.
-      # @param file [String] the file to create
+      # @param path [Pathname]
       # @return [void]
-      def download(file)
-        self.class.get_raw(download_url)[:response].on_complete do |env|
-          File.open(file, 'wb') { |file| file.write(env[:body]) }
-        end
-        nil
+      def download(path)
+        resp = self.class.conn.get(file_url)
+        path.open('wb') { |fh| fh.write(resp.body) }
+      rescue Faraday::ResourceNotFound => e
+        raise PuppetForge::ReleaseNotFound, "The module release #{slug} does not exist on #{conn.url_prefix}.", e.backtrace
       end
+
+      # Verify that a downloaded module matches the checksum in the metadata for this release.
+      #
+      # @param path [Pathname]
+      # @return [void]
+      def verify(path)
+        expected_md5 = file_md5
+        file_md5     = Digest::MD5.file(path).hexdigest
+        if expected_md5 != file_md5
+          raise ChecksumMismatch.new("Expected #{path} checksum to be #{expected_md5}, got #{file_md5}")
+        end
+      end
+
+      private
+
+      def file_url
+        "/v3/files/#{slug}.tar.gz"
+      end
+
+      def resource_url
+        "/v3/releases/#{slug}"
+      end
+
+      class ChecksumMismatch < StandardError
+      end
+
     end
   end
 end

--- a/puppet_forge.gemspec
+++ b/puppet_forge.gemspec
@@ -29,4 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "cane"
   spec.add_development_dependency "yard"
   spec.add_development_dependency "redcarpet"
+
+  spec.add_dependency 'semantic_puppet', '~> 0.1.0'
+  spec.add_dependency 'minitar'
 end

--- a/spec/integration/forge/v3/module_spec.rb
+++ b/spec/integration/forge/v3/module_spec.rb
@@ -3,25 +3,15 @@ require 'spec_helper'
 describe PuppetForge::V3::Module do
   before do
 
-    class PuppetForge::V3::Base
-      class << self
-        def faraday_api
-          @faraday_api = Faraday.new ({ :url => "#{PuppetForge.host}/", :ssl => { :verify => false } }) do |c|
-            c.response :json, :content_type => 'application/json'
-            c.adapter Faraday.default_adapter
-          end
-
-          @faraday_api
-        end
-      end
-    end
-
     PuppetForge.host = "https://forge-aio01-petest.puppetlabs.com/"
+    PuppetForge::V3::Module.conn = PuppetForge::V3::Module.make_connection(PuppetForge.host, nil, {:ssl => {:verify => false} })
+    PuppetForge::V3::User.conn = PuppetForge::V3::User.make_connection(PuppetForge.host, nil, {:ssl => {:verify => false} })
+    PuppetForge::V3::Release.conn = PuppetForge::V3::Release.make_connection(PuppetForge.host, nil, {:ssl => {:verify => false} })
 
   end
 
   context "::find" do
-    context "when the user exists" do
+    context "gets information on an existing module and" do
       let (:mod) { PuppetForge::V3::Module.find('puppetforgegemtesting-thorin') }
 
       it "returns a PuppetForge::V3::Module." do
@@ -42,13 +32,11 @@ describe PuppetForge::V3::Module do
 
     end
 
-    context "when the module doesn't exist" do
-      let (:mod) { PuppetForge::V3::Module.find('puppetforgegemtesting-thorin') }
+    context "raises Faraday::ResourceNotFound when" do
+      let (:mod) { PuppetForge::V3::Module.find('puppetforgegemtesting-bilbo') }
 
-      it "find returns nil." do
-        mod = PuppetForge::V3::Module.find('puppetforgegemtesting-bilbo')
-
-        expect(mod).to be_nil
+      it "the module does not exist" do
+        expect { mod }.to raise_error(Faraday::ResourceNotFound)
       end
 
     end

--- a/spec/integration/forge/v3/release_spec.rb
+++ b/spec/integration/forge/v3/release_spec.rb
@@ -2,49 +2,35 @@ require 'spec_helper'
 
 describe PuppetForge::V3::Release do
   before do
-
-    class PuppetForge::V3::Base
-      class << self
-        def faraday_api
-          @faraday_api = Faraday.new ({ :url => "#{PuppetForge.host}/", :ssl => { :verify => false } }) do |c|
-            c.response :json, :content_type => 'application/json'
-            c.adapter Faraday.default_adapter
-          end
-
-          @faraday_api
-        end
-      end
-    end
-
     PuppetForge.host = "https://forge-aio01-petest.puppetlabs.com/"
-
+    PuppetForge::V3::Module.conn = PuppetForge::V3::Module.make_connection(PuppetForge.host, nil, {:ssl => {:verify => false} })
+    PuppetForge::V3::Release.conn = PuppetForge::V3::Release.make_connection(PuppetForge.host, nil, {:ssl => {:verify => false} })
   end
 
   context "#find" do
     context "when the release exists," do
 
       it "find returns a PuppetForge::V3::Release." do
-        mod = PuppetForge::V3::Release.find('puppetforgegemtesting-thorin-0.0.1')
+        release = PuppetForge::V3::Release.find('puppetforgegemtesting-thorin-0.0.1')
 
-        expect(mod).to be_a(PuppetForge::V3::Release)
+        expect(release).to be_a(PuppetForge::V3::Release)
       end
 
       it "it exposes the API information." do
-        mod = PuppetForge::V3::Release.find('puppetforgegemtesting-thorin-0.0.1')
+        release = PuppetForge::V3::Release.find('puppetforgegemtesting-thorin-0.0.1')
 
-        expect(mod).to respond_to(:uri)
+        expect(release).to respond_to(:uri)
 
-        expect(mod.uri).to be_a(String)
+        expect(release.uri).to be_a(String)
       end
 
     end
 
     context "when the release doesn't exist," do
+      let (:release) { PuppetForge::V3::Release.find('puppetforgegemtesting-bilbo-0.0.1') }
 
       it "find returns nil." do
-        mod = PuppetForge::V3::Release.find('puppetforgegemtesting-bilbo-0.0.1')
-
-        expect(mod).to be_nil
+        expect { release }.to raise_error(Faraday::ResourceNotFound)
       end
 
     end

--- a/spec/integration/forge/v3/user_spec.rb
+++ b/spec/integration/forge/v3/user_spec.rb
@@ -2,22 +2,9 @@ require 'spec_helper'
 
 describe PuppetForge::V3::User do
   before do
-
-    class PuppetForge::V3::Base
-      class << self
-        def faraday_api
-          @faraday_api = Faraday.new ({ :url => "#{PuppetForge.host}/", :ssl => { :verify => false } }) do |c|
-            c.response :json, :content_type => 'application/json'
-            c.adapter Faraday.default_adapter
-          end
-
-          @faraday_api
-        end
-      end
-    end
-
     PuppetForge.host = "https://forge-aio01-petest.puppetlabs.com/"
-
+    PuppetForge::V3::Module.conn = PuppetForge::V3::Module.make_connection(PuppetForge.host, nil, {:ssl => {:verify => false} })
+    PuppetForge::V3::User.conn = PuppetForge::V3::User.make_connection(PuppetForge.host, nil, {:ssl => {:verify => false} })
   end
 
   context "#find" do
@@ -41,10 +28,10 @@ describe PuppetForge::V3::User do
     end
 
     context "when the user doesn't exists," do
+      let (:user) { PuppetForge::V3::User.find('notauser') }
 
       it "find returns nil." do
-        user = PuppetForge::V3::User.find('notauser')
-        expect(user).to be_nil
+        expect { user }.to raise_error(Faraday::ResourceNotFound)
       end
 
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,10 +13,13 @@ require 'puppet_forge'
 module StubbingFaraday
 
   def stub_api_for(klass)
-    allow(klass).to receive(:faraday_api) do
-      Faraday.new :url => "http://api.example.com" do |c|
-        c.response :json, :content_type => 'application/json'
-        c.adapter(:test) { |s| yield(s) }
+    allow(klass).to receive(:conn) do
+      Faraday.new :url => "http://api.example.com" do |builder|
+        builder.response(:json, :content_type => /\bjson$/)
+        builder.response(:raise_error)
+        builder.use(:connection_failure)
+
+        builder.adapter(:test) { |s| yield(s) }
       end
     end
 

--- a/spec/unit/forge/connection/connection_failure_spec.rb
+++ b/spec/unit/forge/connection/connection_failure_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe PuppetForge::Connection::ConnectionFailure do
+
+  subject do
+    Faraday.new('https://my-site.url/some-path') do |builder|
+      builder.use(:connection_failure)
+
+      builder.adapter :test do |stub|
+        stub.get('/connectfail') { raise Faraday::ConnectionFailed.new(SocketError.new("getaddrinfo: Name or service not known"), :hi) }
+      end
+    end
+  end
+
+  it "includes the base URL in the error message" do
+    expect {
+      subject.get('/connectfail')
+    }.to raise_error(Faraday::ConnectionFailed, "Unable to connect to https://my-site.url: getaddrinfo: Name or service not known")
+  end
+
+  it "includes the proxy host in the error message when set" do
+    subject.proxy('https://some-unreachable.proxy:3128')
+    expect {
+      subject.get('/connectfail')
+    }.to raise_error(Faraday::ConnectionFailed, "Unable to connect to https://my-site.url (using proxy https://some-unreachable.proxy:3128): getaddrinfo: Name or service not known")
+  end
+end

--- a/spec/unit/forge/connection_spec.rb
+++ b/spec/unit/forge/connection_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe PuppetForge::Connection do
+
+    let(:test_conn) do
+      class BasicConnection
+        include PuppetForge::Connection
+      end
+
+      BasicConnection.new
+    end
+
+  describe 'creating a new connection' do
+
+    let(:faraday_stubs) { Faraday::Adapter::Test::Stubs.new }
+
+    subject { test_conn.make_connection('https://some.site/url', [:test, faraday_stubs]) }
+
+    it 'parses response bodies with a JSON content-type into a hash' do
+      faraday_stubs.get('/json') { [200, {'Content-Type' => 'application/json'}, '{"hello": "world"}'] }
+      expect(subject.get('/json').body).to eq('hello' => 'world')
+    end
+
+    it 'returns the response body as-is when the content-type is not JSON' do
+      faraday_stubs.get('/binary') { [200, {'Content-Type' => 'application/octet-stream'}, 'I am a big bucket of binary data'] }
+      expect(subject.get('/binary').body).to eq('I am a big bucket of binary data')
+    end
+
+    it 'raises errors when the request has an error status code' do
+      faraday_stubs.get('/error') { [503, {}, "The server caught fire and cannot service your request right now"] }
+
+      expect {
+        subject.get('/error')
+      }.to raise_error(Faraday::ClientError, "the server responded with status 503")
+    end
+
+    context 'when an authorization value is provided' do
+      before(:each) do
+        allow(described_class).to receive(:authorization).and_return("auth-test value")
+      end
+
+      it 'sets authorization header on requests' do
+        expect(subject.headers).to include(:authorization => "auth-test value")
+      end
+    end
+  end
+
+  describe 'creating a default connection' do
+    it 'creates a connection with the default Forge URL' do
+      conn = test_conn.default_connection
+      expect(conn.url_prefix.to_s).to eq 'https://forgeapi.puppetlabs.com/'
+    end
+  end
+end

--- a/spec/unit/forge/tar/mini_spec.rb
+++ b/spec/unit/forge/tar/mini_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+describe PuppetForge::Tar::Mini do
+  let(:entry_class) do
+    Class.new do
+      attr_accessor :typeflag, :name
+      def initialize(name, typeflag)
+        @name = name
+        @typeflag = typeflag
+      end
+    end
+  end
+  let(:sourcefile) { '/the/module.tar.gz' }
+  let(:destdir)    { File.expand_path '/the/dest/dir' }
+  let(:sourcedir)  { '/the/src/dir' }
+  let(:destfile)   { '/the/dest/file.tar.gz' }
+  let(:minitar)    { described_class.new }
+  let(:tarfile_contents) { [entry_class.new('file', '0'), \
+                            entry_class.new('symlink', '2'), \
+                            entry_class.new('invalid', 'F')] }
+
+  it "unpacks a tar file" do
+    unpacks_the_entry(:file_start, 'thefile')
+
+    minitar.unpack(sourcefile, destdir)
+  end
+
+  it "does not allow an absolute path" do
+    unpacks_the_entry(:file_start, '/thefile')
+
+    expect {
+      minitar.unpack(sourcefile, destdir)
+    }.to raise_error(PuppetForge::InvalidPathInPackageError,
+                     "Attempt to install file into \"/thefile\" under \"#{destdir}\"")
+  end
+
+  it "does not allow a file to be written outside the destination directory" do
+    unpacks_the_entry(:file_start, '../../thefile')
+
+    expect {
+      minitar.unpack(sourcefile, destdir)
+    }.to raise_error(PuppetForge::InvalidPathInPackageError,
+                     "Attempt to install file into \"#{File.expand_path('/the/thefile')}\" under \"#{destdir}\"")
+  end
+
+  it "does not allow a directory to be written outside the destination directory" do
+    unpacks_the_entry(:dir, '../../thedir')
+
+    expect {
+      minitar.unpack(sourcefile, destdir)
+    }.to raise_error(PuppetForge::InvalidPathInPackageError,
+                     "Attempt to install file into \"#{File.expand_path('/the/thedir')}\" under \"#{destdir}\"")
+  end
+
+  it "packs a tar file" do
+    writer = double('GzipWriter')
+
+    expect(Zlib::GzipWriter).to receive(:open).with(destfile).and_yield(writer)
+    expect(Archive::Tar::Minitar).to receive(:pack).with(sourcedir, writer)
+
+    minitar.pack(sourcedir, destfile)
+  end
+
+  it "returns filenames in a tar separated into correct categories" do
+    reader = double('GzipReader')
+
+    expect(Zlib::GzipReader).to receive(:open).with(sourcefile).and_yield(reader)
+    expect(Archive::Tar::Minitar).to receive(:open).with(reader).and_return(tarfile_contents)
+    expect(Archive::Tar::Minitar).to receive(:unpack).with(reader, destdir, ['file']).and_yield(:file_start, 'thefile', nil)
+    
+    file_lists = minitar.unpack(sourcefile, destdir)
+
+    expect(file_lists[:valid]).to eq(['file'])
+    expect(file_lists[:invalid]).to eq(['invalid'])
+    expect(file_lists[:symlinks]).to eq(['symlink'])
+  end
+
+  def unpacks_the_entry(type, name)
+    reader = double('GzipReader')
+
+    expect(Zlib::GzipReader).to receive(:open).with(sourcefile).and_yield(reader)
+    expect(minitar).to receive(:validate_files).with(reader).and_return({:valid => [name]})
+    expect(Archive::Tar::Minitar).to receive(:unpack).with(reader, destdir, [name]).and_yield(type, name, nil)
+  end
+end

--- a/spec/unit/forge/tar_spec.rb
+++ b/spec/unit/forge/tar_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe PuppetForge::Tar do
+
+  it "returns an instance of minitar" do
+    expect(described_class.instance).to be_a_kind_of PuppetForge::Tar::Mini
+  end
+
+end

--- a/spec/unit/forge/unpacker_spec.rb
+++ b/spec/unit/forge/unpacker_spec.rb
@@ -1,0 +1,58 @@
+require 'tmpdir'
+require 'spec_helper'
+
+describe PuppetForge::Unpacker do
+
+  let(:source)      { Dir.mktmpdir("source") }
+  let(:target)      { Dir.mktmpdir("unpacker") }
+  let(:module_name) { 'myusername-mytarball' }
+  let(:filename)    { Dir.mktmpdir("module") + "/module.tar.gz" }
+  let(:working_dir) { Dir.mktmpdir("working_dir") }
+  let(:trash_dir)   { Dir.mktmpdir("trash_dir") }
+
+  it "attempts to untar file to temporary location" do
+
+    minitar = double('PuppetForge::Tar::Mini')
+
+    expect(minitar).to receive(:unpack).with(filename, anything()) do |src, dest|
+      FileUtils.mkdir(File.join(dest, 'extractedmodule'))
+      File.open(File.join(dest, 'extractedmodule', 'metadata.json'), 'w+') do |file|
+        file.puts JSON.generate('name' => module_name, 'version' => '1.0.0')
+      end
+      true
+    end
+
+    expect(PuppetForge::Tar).to receive(:instance).and_return(minitar)
+    PuppetForge::Unpacker.unpack(filename, target, trash_dir)
+    expect(File).to be_directory(target)
+  end
+
+  it "returns the appropriate categories of the contents of the tar file from the tar implementation" do
+
+    minitar = double('PuppetForge::Tar::Mini')
+
+    expect(minitar).to receive(:unpack).with(filename, anything()) do |src, dest|
+      FileUtils.mkdir(File.join(dest, 'extractedmodule'))
+      File.open(File.join(dest, 'extractedmodule', 'metadata.json'), 'w+') do |file|
+        file.puts JSON.generate('name' => module_name, 'version' => '1.0.0')
+      end
+      { :valid => [File.join('extractedmodule', 'metadata.json')], :invalid => [], :symlinks => [] }
+    end
+
+    expect(PuppetForge::Tar).to receive(:instance).and_return(minitar)
+    file_lists = PuppetForge::Unpacker.unpack(filename, target, trash_dir)
+    expect(file_lists).to eq({:valid=>["extractedmodule/metadata.json"], :invalid=>[], :symlinks=>[]})
+    expect(File).to be_directory(target)
+  end
+
+  it "attempts to set the ownership of a target dir to a source dir's owner" do
+
+    source_path = Pathname.new(source)
+    target_path = Pathname.new(target)
+
+    expect(FileUtils).to receive(:chown_R).with(source_path.stat.uid, source_path.stat.gid, target_path)
+
+    PuppetForge::Unpacker.harmonize_ownership(source_path, target_path)
+  end
+
+end

--- a/spec/unit/forge/v3/metadata_spec.rb
+++ b/spec/unit/forge/v3/metadata_spec.rb
@@ -1,0 +1,300 @@
+require 'spec_helper'
+
+describe PuppetForge::Metadata do
+  let(:data) { {} }
+  let(:metadata) { PuppetForge::Metadata.new }
+
+  describe 'property lookups' do
+    subject { metadata }
+
+    %w[ name version author summary license source project_page issues_url
+    dependencies dashed_name release_name description ].each do |prop|
+      describe "##{prop}" do
+        it "responds to the property" do
+          subject.send(prop)
+        end
+      end
+    end
+  end
+
+  describe "#update" do
+    subject { metadata.update(data) }
+
+    context "with a valid name" do
+      let(:data) { { 'name' => 'billgates-mymodule' } }
+
+      it "extracts the author name from the name field" do
+        expect(subject.to_hash['author']).to eq('billgates')
+      end
+
+      it "extracts a module name from the name field" do
+        expect(subject.module_name).to eq('mymodule')
+      end
+
+      context "and existing author" do
+        before { metadata.update('author' => 'foo') }
+
+        it "avoids overwriting the existing author" do
+          expect(subject.to_hash['author']).to eq('foo')
+        end
+      end
+    end
+
+    context "with a valid name and author" do
+      let(:data) { { 'name' => 'billgates-mymodule', 'author' => 'foo' } }
+
+      it "use the author name from the author field" do
+        expect(subject.to_hash['author']).to eq('foo')
+      end
+
+      context "and preexisting author" do
+        before { metadata.update('author' => 'bar') }
+
+        it "avoids overwriting the existing author" do
+          expect(subject.to_hash['author']).to eq('foo')
+        end
+      end
+    end
+
+    context "with an invalid name" do
+      context "(short module name)" do
+        let(:data) { { 'name' => 'mymodule' } }
+
+        it "raises an exception" do
+          expect { subject }.to raise_error(ArgumentError, "Invalid 'name' field in metadata.json: the field must be a namespaced module name")
+        end
+      end
+
+      context "(missing namespace)" do
+        let(:data) { { 'name' => '/mymodule' } }
+
+        it "raises an exception" do
+          expect { subject }.to raise_error(ArgumentError, "Invalid 'name' field in metadata.json: the field must be a namespaced module name")
+        end
+      end
+
+      context "(missing module name)" do
+        let(:data) { { 'name' => 'namespace/' } }
+
+        it "raises an exception" do
+          expect { subject }.to raise_error(ArgumentError, "Invalid 'name' field in metadata.json: the field must be a namespaced module name")
+        end
+      end
+
+      context "(invalid namespace)" do
+        let(:data) { { 'name' => "dolla'bill$-mymodule" } }
+
+        it "raises an exception" do
+          expect { subject }.to raise_error(ArgumentError, "Invalid 'name' field in metadata.json: the namespace contains non-alphanumeric characters")
+        end
+      end
+
+      context "(non-alphanumeric module name)" do
+        let(:data) { { 'name' => "dollabils-fivedolla'" } }
+
+        it "raises an exception" do
+          expect { subject }.to raise_error(ArgumentError, "Invalid 'name' field in metadata.json: the module name contains non-alphanumeric (or underscore) characters")
+        end
+      end
+
+      context "(module name starts with a number)" do
+        let(:data) { { 'name' => "dollabills-5dollars" } }
+
+        it "raises an exception" do
+          expect { subject }.to raise_error(ArgumentError, "Invalid 'name' field in metadata.json: the module name must begin with a letter")
+        end
+      end
+    end
+
+
+    context "with an invalid version" do
+      let(:data) { { 'version' => '3.0' } }
+
+      it "raises an exception" do
+        expect { subject }.to raise_error(ArgumentError, "Invalid 'version' field in metadata.json: version string cannot be parsed as a valid Semantic Version")
+      end
+    end
+
+    context "with a valid source" do
+      context "which is a GitHub URL" do
+        context "with a scheme" do
+          before { metadata.update('source' => 'https://github.com/billgates/amazingness') }
+
+          it "predicts a default project_page" do
+            expect(subject.to_hash['project_page']).to eq('https://github.com/billgates/amazingness')
+          end
+
+          it "predicts a default issues_url" do
+            expect(subject.to_hash['issues_url']).to eq('https://github.com/billgates/amazingness/issues')
+          end
+        end
+
+        context "without a scheme" do
+          before { metadata.update('source' => 'github.com/billgates/amazingness') }
+
+          it "predicts a default project_page" do
+            expect(subject.to_hash['project_page']).to eq('https://github.com/billgates/amazingness')
+          end
+
+          it "predicts a default issues_url" do
+            expect(subject.to_hash['issues_url']).to eq('https://github.com/billgates/amazingness/issues')
+          end
+        end
+      end
+
+      context "which is not a GitHub URL" do
+        before { metadata.update('source' => 'https://notgithub.com/billgates/amazingness') }
+
+        it "does not predict a default project_page" do
+          expect(subject.to_hash['project_page']).to be nil
+        end
+
+        it "does not predict a default issues_url" do
+          expect(subject.to_hash['issues_url']).to be nil
+        end
+      end
+
+      context "which is not a URL" do
+        before { metadata.update('source' => 'my brain') }
+
+        it "does not predict a default project_page" do
+          expect(subject.to_hash['project_page']).to be nil
+        end
+
+        it "does not predict a default issues_url" do
+          expect(subject.to_hash['issues_url']).to be nil
+        end
+      end
+
+    end
+
+    context "with a valid dependency", :pending => "dependency resolution is not yet in scope" do
+      let(:data) { {'dependencies' => [{'name' => 'puppetlabs-goodmodule'}] }}
+
+      it "adds the dependency" do
+        expect(subject.dependencies.size).to eq(1)
+      end
+    end
+
+    context "with a invalid dependency name" do
+      let(:data) { {'dependencies' => [{'name' => 'puppetlabsbadmodule'}] }}
+
+      it "raises an exception" do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "with a valid dependency version range", :pending => "dependency resolution is not yet in scope" do
+      let(:data) { {'dependencies' => [{'name' => 'puppetlabs-badmodule', 'version_requirement' => '>= 2.0.0'}] }}
+
+      it "adds the dependency" do
+        expect(subject.dependencies.size).to eq(1)
+      end
+    end
+
+    context "with a invalid version range" do
+      let(:data) { {'dependencies' => [{'name' => 'puppetlabsbadmodule', 'version_requirement' => '>= banana'}] }}
+
+      it "raises an exception" do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "with duplicate dependencies", :pending => "dependency resolution is not yet in scope" do
+      let(:data) { {'dependencies' => [{'name' => 'puppetlabs-dupmodule', 'version_requirement' => '1.0.0'},
+        {'name' => 'puppetlabs-dupmodule', 'version_requirement' => '0.0.1'}] }
+      }
+
+      it "raises an exception" do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "adding a duplicate dependency", :pending => "dependency resolution is not yet in scope" do
+      let(:data) { {'dependencies' => [{'name' => 'puppetlabs-origmodule', 'version_requirement' => '1.0.0'}] }}
+
+      it "with a different version raises an exception" do
+        metadata.add_dependency('puppetlabs-origmodule', '>= 0.0.1')
+        expect { subject }.to raise_error(ArgumentError)
+      end
+
+      it "with the same version does not add another dependency" do
+        metadata.add_dependency('puppetlabs-origmodule', '1.0.0')
+        expect(subject.dependencies.size).to eq(1)
+      end
+    end
+  end
+
+  describe '#dashed_name' do
+    it 'returns nil in the absence of a module name' do
+      expect(metadata.update('version' => '1.0.0').release_name).to be_nil
+    end
+
+    it 'returns a hyphenated string containing namespace and module name' do
+      data = metadata.update('name' => 'foo-bar')
+      expect(data.dashed_name).to eq('foo-bar')
+    end
+
+    it 'properly handles slash-separated names' do
+      data = metadata.update('name' => 'foo/bar')
+      expect(data.dashed_name).to eq('foo-bar')
+    end
+
+    it 'is unaffected by author name' do
+      data = metadata.update('name' => 'foo/bar', 'author' => 'me')
+      expect(data.dashed_name).to eq('foo-bar')
+    end
+  end
+
+  describe '#release_name' do
+    it 'returns nil in the absence of a module name' do
+      expect(metadata.update('version' => '1.0.0').release_name).to be_nil
+    end
+
+    it 'returns nil in the absence of a version' do
+      expect(metadata.update('name' => 'foo/bar').release_name).to be_nil
+    end
+
+    it 'returns a hyphenated string containing module name and version' do
+      data = metadata.update('name' => 'foo/bar', 'version' => '1.0.0')
+      expect(data.release_name).to eq('foo-bar-1.0.0')
+    end
+
+    it 'is unaffected by author name' do
+      data = metadata.update('name' => 'foo/bar', 'version' => '1.0.0', 'author' => 'me')
+      expect(data.release_name).to eq('foo-bar-1.0.0')
+    end
+  end
+
+  describe "#to_hash" do
+    subject { metadata.to_hash }
+
+    it "contains the default set of keys" do
+      expect(subject.keys.sort).to eq(%w[ name version author summary license source issues_url project_page dependencies ].sort)
+    end
+
+    describe "['license']" do
+      it "defaults to Apache 2" do
+        expect(subject['license']).to eq("Apache-2.0")
+      end
+    end
+
+    describe "['dependencies']" do
+      it "defaults to an empty set" do
+        expect(subject['dependencies']).to eq(Set.new)
+      end
+    end
+
+    context "when updated with non-default data" do
+      subject { metadata.update('license' => 'MIT', 'non-standard' => 'yup').to_hash }
+
+      it "overrides the defaults" do
+        expect(subject['license']).to eq('MIT')
+      end
+
+      it 'contains unanticipated values' do
+        expect(subject['non-standard']).to eq('yup')
+      end
+    end
+  end
+end

--- a/spec/unit/forge/v3/module_spec.rb
+++ b/spec/unit/forge/v3/module_spec.rb
@@ -17,7 +17,7 @@ describe PuppetForge::V3::Module do
     end
 
     it 'returns nil for non-existent modules' do
-      expect(missing_mod).to be_nil
+      expect { missing_mod }.to raise_error(Faraday::ResourceNotFound)
     end
   end
 

--- a/spec/unit/forge/v3/release_spec.rb
+++ b/spec/unit/forge/v3/release_spec.rb
@@ -81,7 +81,7 @@ describe PuppetForge::V3::Release do
 
     it 'downloads the file to the specified location' do
       expect(File.exist?(tarball)).to be false
-      release.download(tarball)
+      release.download(Pathname.new(tarball))
       expect(File.exist?(tarball)).to be true
     end
   end

--- a/spec/unit/forge/v3/release_spec.rb
+++ b/spec/unit/forge/v3/release_spec.rb
@@ -17,8 +17,8 @@ describe PuppetForge::V3::Release do
       expect(release.version).to eql('0.0.1')
     end
 
-    it 'returns nil for non-existent releases' do
-      expect(missing_release).to be nil
+    it 'raises Faraday::ResourceNotFound for non-existent releases' do
+      expect { missing_release }.to raise_error(Faraday::ResourceNotFound)
     end
   end
 

--- a/spec/unit/forge/v3/user_spec.rb
+++ b/spec/unit/forge/v3/user_spec.rb
@@ -16,8 +16,8 @@ describe PuppetForge::V3::User do
       expect(user.username).to eq('puppetlabs')
     end
 
-    it 'returns nil for non-existent users' do
-      expect(missing_user).to be_nil
+    it 'raises Faraday::ResourceNotFound for non-existent users' do
+      expect { missing_user }.to raise_error(Faraday::ResourceNotFound)
     end
   end
 


### PR DESCRIPTION
Before this commit, the puppet_forge gem was not able to downlaod
releases. With this commit, the gem is able to download and verify the
MD5 of a release.

The find method now raises a Faraday::ResourceNotFound instead of
returning nil when the resource does not exist.