### PR TITLE
(CODEMGMT-307) Get PuppetForge usable by r10k

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Starting with v2.0.0, all notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).i
 
+## v2.1.0 - 2015-08-20
+
+### Added
+
+* PuppetForge::ReleaseForbidden added to acknowledge 403 status returned from release download request
+
 ## v2.0.0 - 2015-08-13
 
 ### Added

--- a/lib/puppet_forge/error.rb
+++ b/lib/puppet_forge/error.rb
@@ -31,4 +31,11 @@ Could not install package
 
   class ReleaseNotFound < PuppetForge::Error
   end
+
+  class ReleaseForbidden < PuppetForge::Error
+    def self.from_response(response)
+      body = JSON.parse(response[:body])
+      new(body["message"])
+    end
+  end
 end

--- a/lib/puppet_forge/v3/release.rb
+++ b/lib/puppet_forge/v3/release.rb
@@ -1,5 +1,6 @@
 require 'puppet_forge/v3/base'
 require 'puppet_forge/v3/module'
+require 'json'
 
 module PuppetForge
   module V3
@@ -28,6 +29,12 @@ module PuppetForge
         path.open('wb') { |fh| fh.write(resp.body) }
       rescue Faraday::ResourceNotFound => e
         raise PuppetForge::ReleaseNotFound, "The module release #{slug} does not exist on #{conn.url_prefix}.", e.backtrace
+      rescue Faraday::ClientError => e
+        if e.response[:status] == 403
+          raise PuppetForge::ModuleReleaseForbidden.from_response(e.response)
+        else
+          raise e
+        end
       end
 
       # Verify that a downloaded module matches the checksum in the metadata for this release.

--- a/lib/puppet_forge/version.rb
+++ b/lib/puppet_forge/version.rb
@@ -1,3 +1,3 @@
 module PuppetForge
-  VERSION = '2.0.0' # Library version
+  VERSION = '2.1.0' # Library version
 end


### PR DESCRIPTION
With this commit, forge-ruby/puppet_forge should be in a state that it is usable by r10k 2.0.3. This includes some minor changes for usability with pe_license, and and a minor version bump.

I will publish the library to rubygems once this PR is merged.