### PR TITLE
(CODEMGMT-307) Update puppet_forge gem for use with r10k

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Starting with v2.0.0, all notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).i
 
+## v2.1.0 - 2015-08-20
+
+### Added
+
+* PuppetForge::ReleaseForbidden added to acknowledge 403 status returned from release download request
+
 ## v2.0.0 - 2015-08-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -212,3 +212,5 @@ to create a free account to add new tickets.
 * Pieter van de Bruggen, Puppet Labs
 * Jesse Scott, Puppet Labs
 * Austin Blatt, Puppet Labs
+* Adrien Thebo, Puppet Labs
+* Anderson Mills, Puppet Labs

--- a/lib/puppet_forge/error.rb
+++ b/lib/puppet_forge/error.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module PuppetForge
   class Error < RuntimeError
     attr_accessor :original
@@ -30,5 +32,12 @@ Could not install package
   end
 
   class ReleaseNotFound < PuppetForge::Error
+  end
+
+  class ReleaseForbidden < PuppetForge::Error
+    def self.from_response(response)
+      body = JSON.parse(response[:body])
+      new(body["message"])
+    end
   end
 end

--- a/lib/puppet_forge/v3/release.rb
+++ b/lib/puppet_forge/v3/release.rb
@@ -28,6 +28,12 @@ module PuppetForge
         path.open('wb') { |fh| fh.write(resp.body) }
       rescue Faraday::ResourceNotFound => e
         raise PuppetForge::ReleaseNotFound, "The module release #{slug} does not exist on #{conn.url_prefix}.", e.backtrace
+      rescue Faraday::ClientError => e
+        if e.response[:status] == 403
+          raise PuppetForge::ReleaseForbidden.from_response(e.response)
+        else
+          raise e
+        end
       end
 
       # Verify that a downloaded module matches the checksum in the metadata for this release.

--- a/lib/puppet_forge/version.rb
+++ b/lib/puppet_forge/version.rb
@@ -1,3 +1,3 @@
 module PuppetForge
-  VERSION = '2.0.0' # Library version
+  VERSION = '2.1.0' # Library version
 end


### PR DESCRIPTION
This commit:

- adds a forbidden release error and the use of that error when downloading a release.  These were added to the shared puppet_forge code before r10k was made dependent on the puppet_forge gem.
- updates the version number to 2.1.0 and the CHANGELOG and README.
- fixes a problem with ReleaseForbidden error call.