### PR TITLE
(RK-170) Bad error on missing release.

### DIFF
--- a/lib/puppet_forge/v3/release.rb
+++ b/lib/puppet_forge/v3/release.rb
@@ -27,7 +27,7 @@ module PuppetForge
         resp = self.class.conn.get(file_url)
         path.open('wb') { |fh| fh.write(resp.body) }
       rescue Faraday::ResourceNotFound => e
-        raise PuppetForge::ReleaseNotFound, "The module release #{slug} does not exist on #{conn.url_prefix}.", e.backtrace
+        raise PuppetForge::ReleaseNotFound, "The module release #{slug} does not exist on #{self.class.conn.url_prefix}.", e.backtrace
       rescue Faraday::ClientError => e
         if e.response[:status] == 403
           raise PuppetForge::ReleaseForbidden.from_response(e.response)


### PR DESCRIPTION
Before this commit, the error message coming back from a missing module
relese was unhelpful. This corrects it back to what was expected. ("The
module release blah-1.0.0 does not exist on
https://forgeapi.puppetlabs.com")