### PR TITLE
(CODEMGMT-725) Externalize strings for i18n

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ _yardoc
 *.o
 *.a
 mkmf.log
+locales/forge-ruby.pot

--- a/README.md
+++ b/README.md
@@ -186,6 +186,26 @@ user.username # => "puppetlabs"
 user.created_at # => "2010-05-19 05:46:26 -0700"
 ```
 
+### i18n
+
+When adding new error or log messages please follow the instructions for
+[writing translatable code](https://github.com/puppetlabs/gettext-setup-gem#writing-translatable-code).
+
+The PuppetForge gem will default to outputing all error messages in English, but you may set the locale
+using the `FastGettext.set_locale` method. If translations do not exist for the language you request then the gem will
+default to English. The `set_locale` method will return the locale, as a string, that FastGettext will now
+use to report PuppetForge errors.
+
+``` ruby
+# Assuming the German translations exist, this will set the reporting language
+# to German
+
+locale = FastGettext.set_locale "de_DE"
+
+# If it successfully finds Germany's locale, locale will be "de_DE"
+# If it fails to find any German locale, locale will be "en"
+```
+
 ##Caveats
 
 This library currently does no response caching of its own, instead opting to

--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,7 @@
 require "bundler/gem_tasks"
 
+# i18n/gettext Rake tasks
+spec = Gem::Specification.find_by_name 'gettext-setup'
+load "#{spec.gem_dir}/lib/tasks/gettext.rake"
+GettextSetup.initialize(File.absolute_path('locales', File.dirname(__FILE__)))
+

--- a/lib/puppet_forge.rb
+++ b/lib/puppet_forge.rb
@@ -1,10 +1,13 @@
 require 'puppet_forge/version'
+require 'gettext-setup'
 
 module PuppetForge
   class << self
     attr_accessor :user_agent
     attr_accessor :host
   end
+
+  GettextSetup.initialize(File.absolute_path('../locales', File.dirname(__FILE__)))
 
   self.host = 'https://forgeapi.puppetlabs.com'
 

--- a/lib/puppet_forge/connection/connection_failure.rb
+++ b/lib/puppet_forge/connection/connection_failure.rb
@@ -10,9 +10,10 @@ module PuppetForge
       rescue Faraday::ConnectionFailed => e
         baseurl = env[:url].dup
         baseurl.path = ''
-        errmsg = "Unable to connect to #{baseurl.to_s}"
         if proxy = env[:request][:proxy]
-          errmsg << " (using proxy #{proxy.uri.to_s})"
+          errmsg = _("Unable to connect to %{url} (using proxy %{proxy})") % {url: baseurl.to_s, proxy: proxy.uri.to_s}
+        else
+          errmsg = _("Unable to connect to %{url}") % {url: baseurl.to_s}
         end
         errmsg << ": #{e.message}"
         m = Faraday::ConnectionFailed.new(errmsg)

--- a/lib/puppet_forge/error.rb
+++ b/lib/puppet_forge/error.rb
@@ -16,15 +16,11 @@ module PuppetForge
     def initialize(options)
       @entry_path = options[:entry_path]
       @directory  = options[:directory]
-      super "Attempt to install file into #{@entry_path.inspect} under #{@directory.inspect}"
+      super _("Attempt to install file into %{path} under %{directory}") % {path: @entry_path.inspect, directory: @directory.inspect}
     end
 
     def multiline
-      <<-MSG.strip
-Could not install package
-  Package attempted to install file into
-  #{@entry_path.inspect} under #{@directory.inspect}.
-      MSG
+      _("Could not install package\n  Package attempted to install file into\n  %{path} under %{directory}.") % {path: @entry_path.inspect, directory: @directory.inspect}
     end
   end
 

--- a/lib/puppet_forge/lazy_relations.rb
+++ b/lib/puppet_forge/lazy_relations.rb
@@ -24,7 +24,7 @@ module PuppetForge
       version = class_name.split("::")[-2]
 
       if version.nil?
-        raise RuntimeError, "Unable to determine the parent PuppetForge version module"
+        raise RuntimeError, _("Unable to determine the parent PuppetForge version module")
       end
 
       PuppetForge.const_get(version)

--- a/lib/puppet_forge/unpacker.rb
+++ b/lib/puppet_forge/unpacker.rb
@@ -39,7 +39,7 @@ module PuppetForge
       begin
         PuppetForge::Tar.instance.unpack(@filename, @tmpdir)
       rescue PuppetForge::ExecutionFailure => e
-        raise RuntimeError, "Could not extract contents of module archive: #{e.message}"
+        raise RuntimeError, _("Could not extract contents of module archive: %{error_msg}") % {error_msg: e.message}
       end
     end
 
@@ -61,7 +61,7 @@ module PuppetForge
       if metadata_file
         @root_dir = Pathname.new(metadata_file).dirname
       else
-        raise "No valid metadata.json found!"
+        raise _("No valid metadata.json found!")
       end
     end
   end

--- a/lib/puppet_forge/v3/metadata.rb
+++ b/lib/puppet_forge/v3/metadata.rb
@@ -63,7 +63,7 @@ module PuppetForge
         validate_version_range(version_requirement) if version_requirement
 
         if dup = @data['dependencies'].find { |d| d.full_module_name == name && d.version_requirement != version_requirement }
-          raise ArgumentError, "Dependency conflict for #{full_module_name}: Dependency #{name} was given conflicting version requirements #{version_requirement} and #{dup.version_requirement}. Verify that there are no duplicates in the metadata.json or the Modulefile."
+          raise ArgumentError, _("Dependency conflict for %{module_name}: Dependency %{conflict_name} was given conflicting version requirements %{version} and %{conflict_version}. Verify that there are no duplicates in the metadata.json or the Modulefile.") % {module_name: full_module_name, conflict_name: name, version: version_requirement, conflict_version: dup.version_requirement}
         end
 
         dep = Dependency.new(name, version_requirement, repository)
@@ -165,31 +165,30 @@ module PuppetForge
 
         err = case modname
         when nil, '', :namespace_missing
-          "the field must be a namespaced module name"
+          _("the field must be a namespaced module name")
         when /[^a-z0-9_]/i
-          "the module name contains non-alphanumeric (or underscore) characters"
+          _("the module name contains non-alphanumeric (or underscore) characters")
         when /^[^a-z]/i
-          "the module name must begin with a letter"
+          _("the module name must begin with a letter")
         else
-          "the namespace contains non-alphanumeric characters"
+          _("the namespace contains non-alphanumeric characters")
         end
 
-        raise ArgumentError, "Invalid 'name' field in metadata.json: #{err}"
+        raise ArgumentError, _("Invalid 'name' field in metadata.json: %{error}") % {error: err}
       end
 
       # Validates that the version string can be parsed by SemanticPuppet.
       def validate_version(version)
         return if SemanticPuppet::Version.valid?(version)
 
-        err = "version string cannot be parsed as a valid Semantic Version"
-        raise ArgumentError, "Invalid 'version' field in metadata.json: #{err}"
+        raise ArgumentError, _("Invalid 'version' field in metadata.json: version string cannot be parsed as a valid Semantic Version")
       end
 
       # Validates that the version range can be parsed by SemanticPuppet.
       def validate_version_range(version_range)
         SemanticPuppet::VersionRange.parse(version_range)
       rescue ArgumentError => e
-        raise ArgumentError, "Invalid 'version_range' field in metadata.json: #{e}"
+        raise ArgumentError, _("Invalid 'version_range' field in metadata.json: %{error}") % {error: e} 
       end
     end
   end

--- a/lib/puppet_forge/v3/release.rb
+++ b/lib/puppet_forge/v3/release.rb
@@ -27,7 +27,7 @@ module PuppetForge
         resp = self.class.conn.get(download_url)
         path.open('wb') { |fh| fh.write(resp.body) }
       rescue Faraday::ResourceNotFound => e
-        raise PuppetForge::ReleaseNotFound, "The module release #{slug} does not exist on #{self.class.conn.url_prefix}.", e.backtrace
+        raise PuppetForge::ReleaseNotFound, (_("The module release %{release_slug} does not exist on %{url}.") % {release_slug: slug, url: self.class.conn.url_prefix}), e.backtrace
       rescue Faraday::ClientError => e
         if e.response && e.response[:status] == 403
           raise PuppetForge::ReleaseForbidden.from_response(e.response)

--- a/locales/config.yaml
+++ b/locales/config.yaml
@@ -1,0 +1,21 @@
+---
+# This is the project-specific configuration file for setting up
+# fast_gettext for your project.
+gettext:
+  # This is used for the name of the .pot and .po files; they will be
+  # called <project_name>.pot?
+  project_name: 'forge-ruby'
+  # This is used in comments in the .pot and .po files to indicate what
+  # project the files belong to and should bea little more desctiptive than
+  # <project_name>
+  package_name: Puppet Forge Gem
+  # The locale that the default messages in the .pot file are in
+  default_locale: en
+  # The email used for sending bug reports.
+  bugs_address: docs@puppetlabs.com
+  # The holder of the copyright.
+  copyright_holder: Puppet, Inc.
+  # Patterns for +Dir.glob+ used to find all files that might contain
+  # translatable content, relative to the project root directory
+  source_files:
+    - 'lib/**/*.rb'

--- a/puppet_forge.gemspec
+++ b/puppet_forge.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "faraday_middleware", [">= 0.9.0", "< 0.11.0"]
   spec.add_dependency 'semantic_puppet', '~> 0.1.0'
   spec.add_dependency 'minitar'
+  spec.add_dependency 'gettext-setup', '>= 0.3'
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
This adds the i18n library and externalizes error message strings
for i18n. A 'set_locale' method has also been added to allow the
user of the puppet_forge gem to set its locale