### PR TITLE
Allow path prefix for non forge module repositories

### DIFF
--- a/lib/puppet_forge/v3/base.rb
+++ b/lib/puppet_forge/v3/base.rb
@@ -60,15 +60,10 @@ module PuppetForge
             conn.url_prefix = "#{PuppetForge.host}"
           end
 
-          path_prefix = conn.path_prefix.clone
-          
-          unless path_prefix.end_with?("/") 
-          	 path_prefix = path_prefix + "/"
-          end
           if item.nil?
-            uri_path = "#{path_prefix}v3/#{resource}"
+            uri_path = "v3/#{resource}"
           else
-            uri_path = "#{path_prefix}v3/#{resource}/#{item}"
+            uri_path = "v3/#{resource}/#{item}"
           end
 
           PuppetForge::V3::Base.conn.get uri_path, params

--- a/lib/puppet_forge/v3/base.rb
+++ b/lib/puppet_forge/v3/base.rb
@@ -60,10 +60,15 @@ module PuppetForge
             conn.url_prefix = "#{PuppetForge.host}"
           end
 
+          path_prefix = conn.path_prefix.clone
+          
+          unless path_prefix.end_with?("/") 
+          	 path_prefix = path_prefix + "/"
+          end
           if item.nil?
-            uri_path = "/v3/#{resource}"
+            uri_path = "#{path_prefix}v3/#{resource}"
           else
-            uri_path = "/v3/#{resource}/#{item}"
+            uri_path = "#{path_prefix}v3/#{resource}/#{item}"
           end
 
           PuppetForge::V3::Base.conn.get uri_path, params


### PR DESCRIPTION
I've created a plugin for nexus to mimic a forge module repository.  The problem is that the url paths (/v3/releases/...) are not off the root.

For example my base url is http://nexus_host:8081/nexus/service/siesta/puppetforge/puppet and I need the library to query http://nexus_host:8081/nexus/service/siesta/puppetforge/puppet/v3/releases/...

This change allows the user to specify a longer url that will prefix initial requests to the server.