### PR TITLE
Specify activesupport version more granularly.

### DIFF
--- a/puppet_forge.gemspec
+++ b/puppet_forge.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
+  spec.add_runtime_dependency "activesupport", "~> 4.2"
   spec.add_runtime_dependency "her", "~> 0.6.8"
 
   spec.add_development_dependency "bundler", "~> 1.6"


### PR DESCRIPTION
Because of 1.x dependency on the Her gem, it also depends on
activesupport. On June 30, activesupport 5 was released which only
supports ruby >= 2. Her's dependency on activesupport allows this
gem to pull in activesupport 5, which breaks this gem in ruby < 2.