### PR TITLE
Fix connection test for some random orders

### DIFF
--- a/spec/unit/forge/connection_spec.rb
+++ b/spec/unit/forge/connection_spec.rb
@@ -13,6 +13,10 @@ describe PuppetForge::Connection do
     subject { described_class }
 
     describe '#proxy=' do
+      after(:each) do
+        subject.proxy = nil
+      end
+
       it "sets @proxy to value when passed non-empty string" do
         proxy = "http://proxy.example.com:3128"
 


### PR DESCRIPTION
The proxy setting of `"http://proxy.example.com:3128"` would sometimes carry over to the integration tests.

Run with the `--seed 27590` to run in an order that can produce the error.

``` ruby
bundle exec rspec --seed 27590 --color
```
