### PR TITLE
Ensure consistent behaviour in setter for host with non String input

### DIFF
--- a/lib/puppet_forge.rb
+++ b/lib/puppet_forge.rb
@@ -7,6 +7,7 @@ module PuppetForge
     attr_reader :host
 
     def host=(new_host)
+      new_host = new_host.to_s
       new_host << '/' unless new_host[-1] == '/'
 
       # TODO: maybe freeze this


### PR DESCRIPTION
New host setter assumes String behaviours whereas librarian-puppet passes URI object, for safety ensure Strings are used for host