### PR TITLE
relax dependency on faraday

### DIFF
--- a/puppet_forge.gemspec
+++ b/puppet_forge.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_runtime_dependency "faraday", "~> 0.9.0"
+  spec.add_runtime_dependency "faraday", "~> 0.9"
   spec.add_runtime_dependency "faraday_middleware", [">= 0.9.0", "< 0.11.0"]
   spec.add_dependency 'semantic_puppet', '~> 1.0'
   spec.add_dependency 'minitar'


### PR DESCRIPTION
faraday promises compatibility with minor updates lostisland/faraday#515 and many libraries already declare a relaxed requirement.