### PR TITLE
(RK-306) Add helper method in puppet_forge for valid semantic version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Starting with v2.0.0, all notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## dev
+
+### Added
+
+Created PuppetForge::Util class with a single method, version_valid? in order to
+drop the r10k dependency on semantic_puppet.
+
 ## v2.2.7 - 2017-06-30
 
 ### Changed
@@ -19,7 +26,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-* (FORGE-338) Fixed an issue where `V3::Release.download_url` returned an incorrect value when `PuppetForge.host` included 
+* (FORGE-338) Fixed an issue where `V3::Release.download_url` returned an incorrect value when `PuppetForge.host` included
   a path prefix. (Thanks to [Jainish Shah](https://github.com/jainishshah17) for the report and initial fix proposal.)
 
 ## v2.2.4 - 2017-04-17

--- a/lib/puppet_forge/util.rb
+++ b/lib/puppet_forge/util.rb
@@ -1,0 +1,9 @@
+require 'semantic_puppet'
+
+module PuppetForge
+  class Util
+    def self.version_valid?(version)
+        return SemanticPuppet::Version.valid?(version)
+    end
+  end
+end

--- a/spec/unit/forge/util_spec.rb
+++ b/spec/unit/forge/util_spec.rb
@@ -1,0 +1,17 @@
+require 'puppet_forge/util'
+
+describe PuppetForge::Util do
+
+  describe "version_valid?" do
+    it "returns true for a valid version" do
+      expect(described_class.version_valid?('1.0.0')).to equal(true)
+    end
+
+
+    it "returns false for an invalid version" do
+      expect(described_class.version_valid?('notaversion')).to equal(false)
+    end
+
+  end
+
+end


### PR DESCRIPTION
This commit passes through the Semantic::Version.valid? method so that
r10k can drop a dependency on semantic_puppet.