### PR TITLE
Allow for higher versions of faraday

### DIFF
--- a/puppet_forge.gemspec
+++ b/puppet_forge.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_runtime_dependency "faraday", "~> 0.9.0"
-  spec.add_runtime_dependency "faraday_middleware", [">= 0.9.0", "< 0.11.0"]
+  spec.add_runtime_dependency "faraday", [">= 0.9.0", "< 0.14.0"]
+  spec.add_runtime_dependency "faraday_middleware", [">= 0.9.0", "< 0.13.0"]
   spec.add_dependency 'semantic_puppet', '~> 1.0'
   spec.add_dependency 'minitar'
   spec.add_dependency 'gettext-setup', '~> 0.11'


### PR DESCRIPTION
This allows for people who need a higher version of faraday for other
gems to be able to meet that requirement without forcing existing users
to upgrade their current version.