### PR TITLE
(MAINT) Move deploy to distinct build stage and update api_key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,14 @@ rvm:
   - 2.1
 # TODO: enable integration testing
 script: bundle exec rspec spec/unit
-deploy:
-  on:
-    tags: true
-  provider: rubygems
-  gem: puppet_forge
-  api_key:
-    # jesse@puppet key, will need to update if user is removed
-    # from gem admin role
-    secure: m3uLKgLNxhMni9PYLP3tKqtw7N7ZUR0FUjS5cA2a0Dh6SrQhZiE1Mlxn742pk5cmGWI0fBz1i4q/I2oqXTdAWadeYmiiBID4R2qT2uwroX//flHfar/Qx0knKEdH6J2InSwdUWMLFlkjihOdKTnqmIVfD8UiLfNXA5QgJLgXGKI=
+jobs:
+  include:
+    - stage: deploy
+      if: tag IS present
+      rvm: 2.6
+      script: echo "Deploying to rubygems.org..."
+      deploy:
+        provider: rubygems
+        gem: puppet_forge
+        api_key:
+          secure: 066s1nJoYzCPzujfTAZ1OiDbbHghLIfW2SxZ/xTom7SbtYlb4SVOUkzOr6dLMysUBAWLQRwiFvgNij+iWwHoNEPqNA+JeGZIiL32ShQI0NW+lTcjPzeAe8Ppy/1pxgXFSJAPHLzdpdgiK91eM4vMWHIaOqPeT/4+X2+kmWbg71E=


### PR DESCRIPTION
Previously, every cell in the matrix was trying to deploy at the end,
this should change it to only do one deploy after every cell of the test
matrix passes.

Also, the api_key was previously encrypted for travis-ci.org whereas the
current integration is using travis-ci.com which requires a different
encrypted value.