### PR TITLE
(PE-27712) Allow faraday to go to version 0.14.0

### DIFF
--- a/puppet_forge.gemspec
+++ b/puppet_forge.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_runtime_dependency "faraday", [">= 0.9.0", "< 0.14.0"]
+  spec.add_runtime_dependency "faraday", [">= 0.9.0", "< 0.15.0", "!= 0.13.1"]
   spec.add_runtime_dependency "faraday_middleware", [">= 0.9.0", "< 0.13.0"]
   spec.add_dependency 'semantic_puppet', '~> 1.0'
   spec.add_dependency 'minitar'


### PR DESCRIPTION
Users discovered an issue where faraday 0.13.1 does not correctly
respect proxy settings unless they are set in the environment. This gem
sets them programmatically, and in 0.13.1, that is ignored. This caused
issues with proxies configured for r10k. This commit updates the max
allowed version of faraday to inclue 0.14.0, where this issue was fixed.