### PR TITLE
allow faraday_middleware 0.13.X

### DIFF
--- a/puppet_forge.gemspec
+++ b/puppet_forge.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_runtime_dependency "faraday", [">= 0.9.0", "< 0.15.0", "!= 0.13.1"]
-  spec.add_runtime_dependency "faraday_middleware", [">= 0.9.0", "< 0.13.0"]
+  spec.add_runtime_dependency "faraday_middleware", [">= 0.9.0", "< 0.14.0"]
   spec.add_dependency 'semantic_puppet', '~> 1.0'
   spec.add_dependency 'minitar'
   spec.add_dependency 'gettext-setup', '~> 0.11'


### PR DESCRIPTION
faraday_middleware 0.13.1 got released on 2019-02-04.