### PR TITLE
(MAINT) Remove ruby 2.3 github checks

### DIFF
--- a/.github/workflows/ruby-rspec.yml
+++ b/.github/workflows/ruby-rspec.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version: ['2.6.x', '2.5.x', '2.4.x', '2.3.x']
+        ruby_version: ['2.6.x', '2.5.x', '2.4.x']
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
These don't pass, and since puppet 5 (the oldest supported puppet
series) ships with ruby 2.4, we'll stop testing with 2.3.