### PR TITLE
Add Ruby 2.7 to GitHub Actions testmatrix

### DIFF
--- a/.github/workflows/ruby-rspec.yml
+++ b/.github/workflows/ruby-rspec.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby_version: ['2.6.x', '2.5.x', '2.4.x']
+        ruby_version: ['2.7.x', '2.6.x', '2.5.x', '2.4.x']
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Ruby 2.7 got released some time ago and the first distributions start to
ship it. We should therefore also run the testsuite on that version.