### PR TITLE
(RK-358) Handle TimeoutErrors from Faraday

### DIFF
--- a/lib/puppet_forge/connection/connection_failure.rb
+++ b/lib/puppet_forge/connection/connection_failure.rb
@@ -7,7 +7,7 @@ module PuppetForge
     class ConnectionFailure < Faraday::Middleware
       def call(env)
         @app.call(env)
-      rescue Faraday::ConnectionFailed => e
+      rescue Faraday::ConnectionFailed, Faraday::TimeoutError => e
         baseurl = env[:url].dup
         if proxy = env[:request][:proxy]
           errmsg = _("Unable to connect to %{scheme}://%{host} (using proxy %{proxy}) (for request %{path_query})") % {

--- a/spec/unit/forge/connection/connection_failure_spec.rb
+++ b/spec/unit/forge/connection/connection_failure_spec.rb
@@ -11,6 +11,7 @@ describe PuppetForge::Connection::ConnectionFailure do
 
       builder.adapter :test do |stub|
         stub.get('/connectfail') { raise Faraday::ConnectionFailed.new(SocketError.new("getaddrinfo: Name or service not known"), :hi) }
+        stub.get('/timeout') { raise Faraday::TimeoutError, "request timed out" }
       end
     end
   end
@@ -19,6 +20,12 @@ describe PuppetForge::Connection::ConnectionFailure do
     expect {
       subject.get('/connectfail')
     }.to raise_error(Faraday::ConnectionFailed, /unable to connect to.*\/connectfail.*name or service not known/i)
+  end
+
+  it "logs for timeout errors" do
+    expect {
+      subject.get('/timeout')
+    }.to raise_error(Faraday::ConnectionFailed, /unable to connect to.*\/timeout.*request timed out/i)
   end
 
   it "includes the proxy host in the error message when set" do


### PR DESCRIPTION
Recently, libcurl started sending timeout error codes instead of the
more generic "couldn't connect". The typheous adapter that we use with
Faraday surfaces these as `Faraday::TimeoutError` instead of
`Faraday::ConnectionFailed`. But we still want similar logging when the
request times out, so this commit updates our error handling to also
catch the `TimeoutError`.