### PR TITLE
use latest faraday

### DIFF
--- a/puppet_forge.gemspec
+++ b/puppet_forge.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_runtime_dependency "faraday", [">= 0.9.0", "< 0.15.0", "!= 0.13.1"]
+  spec.add_runtime_dependency "faraday", [">= 0.9.0", "<= 0.17.3", "!= 0.13.1"]
   spec.add_runtime_dependency "faraday_middleware", [">= 0.9.0", "< 0.14.0"]
   spec.add_dependency 'semantic_puppet', '~> 1.0'
   spec.add_dependency 'minitar'


### PR DESCRIPTION
test-kitchen is throwing ugly warnings. From inspecting my Gemfile.lock file I think it's due to my use of kitchen-puppet, that uses librarian-puppet, that uses forge-ruby, that uses faraday.

This issue has been fixed in Faraday 0.17.1 and on per https://github.com/lostisland/faraday/issues/989 and https://github.com/lostisland/faraday/pull/1009.

Looks like I'll need to keep fixing after this. Gemfile.lock snippet:

```
    librarian-puppet (3.0.0) 
      puppet_forge (~> 2.1)
```

test-kitchen error:

```
/Users/aerickson/git/ronin_puppet/vendor/ruby/2.7.0/gems/faraday-0.14.0/lib/faraday/options.rb:166: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/Users/aerickson/git/ronin_puppet/vendor/ruby/2.7.0/gems/faraday-0.14.0/lib/faraday/options.rb:166: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/Users/aerickson/git/ronin_puppet/vendor/ruby/2.7.0/gems/faraday-0.14.0/lib/faraday/options.rb:166: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/Users/aerickson/git/ronin_puppet/vendor/ruby/2.7.0/gems/faraday-0.14.0/lib/faraday/options.rb:166: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
/Users/aerickson/git/ronin_puppet/vendor/ruby/2.7.0/gems/faraday-0.14.0/lib/faraday/options.rb:166: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
```