### PR TITLE
(MAINT) Allow newer versions of faraday

### DIFF
--- a/puppet_forge.gemspec
+++ b/puppet_forge.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_runtime_dependency "faraday", [">= 0.9.0", "< 0.15.0", "!= 0.13.1"]
+  spec.add_runtime_dependency "faraday", [">= 0.9.0", "< 0.18.0", "!= 0.13.1"]
   spec.add_runtime_dependency "faraday_middleware", [">= 0.9.0", "< 0.14.0"]
   spec.add_dependency 'semantic_puppet', '~> 1.0'
   spec.add_dependency 'minitar'


### PR DESCRIPTION
Increases the upper bound of the faraday dependency to anything under 0.18. Not sure we can allow version 1.0 yet, but this should hold us for a while.