### PR TITLE
(MAINT) Allow newer versions of faraday_middleware

### DIFF
--- a/puppet_forge.gemspec
+++ b/puppet_forge.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_runtime_dependency "faraday", [">= 0.9.0", "< 0.18.0", "!= 0.13.1"]
-  spec.add_runtime_dependency "faraday_middleware", [">= 0.9.0", "<= 0.14.0"]
+  spec.add_runtime_dependency "faraday_middleware", [">= 0.9.0", "< 0.15.0"]
   spec.add_dependency 'semantic_puppet', '~> 1.0'
   spec.add_dependency 'minitar'
   spec.add_dependency 'gettext-setup', '~> 0.11'

--- a/puppet_forge.gemspec
+++ b/puppet_forge.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_runtime_dependency "faraday", [">= 0.9.0", "< 0.18.0", "!= 0.13.1"]
-  spec.add_runtime_dependency "faraday_middleware", [">= 0.9.0", "< 0.14.0"]
+  spec.add_runtime_dependency "faraday_middleware", [">= 0.9.0", "<= 0.14.0"]
   spec.add_dependency 'semantic_puppet', '~> 1.0'
   spec.add_dependency 'minitar'
   spec.add_dependency 'gettext-setup', '~> 0.11'


### PR DESCRIPTION
Allow use of faraday_middleware v0.14.0.

https://rubygems.org/gems/faraday_middleware

warning seen:
> /Users/aerickson/git/ronin_puppet/vendor/ruby/2.7.0/gems/faraday_middleware-0.13.1/lib/faraday_middleware/response_middleware.rb:14: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead

The warning can also been seen on master with 2.7 (or a PR like https://github.com/puppetlabs/forge-ruby/pull/81/checks?check_run_id=459193126).

fixed upstream in https://github.com/lostisland/faraday_middleware/pull/189