### PR TITLE
fix ruby 2.7 warning about "deprecated Object#=~"

### DIFF
--- a/lib/puppet_forge/v3/base.rb
+++ b/lib/puppet_forge/v3/base.rb
@@ -56,7 +56,7 @@ module PuppetForge
         # @private
         def request(resource, item = nil, params = {}, reset_connection = false, conn_opts = {})
           conn(reset_connection, conn_opts) if reset_connection
-          unless conn.url_prefix =~ /^#{PuppetForge.host}/
+          unless conn.url_prefix.to_s =~ /^#{PuppetForge.host}/
             conn.url_prefix = "#{PuppetForge.host}"
           end
 


### PR DESCRIPTION
Getting a ton of these errors:

> ./Users/aerickson/git/forge-ruby/lib/puppet_forge/v3/base.rb:59: warning: deprecated Object#=~ is called on URI::HTTP; it always returns nil

They can be seen when inspecting the "Build and test with Rspec" step of the tests on master (or another PR like https://github.com/puppetlabs/forge-ruby/pull/80/checks?check_run_id=459172469) with ruby 2.7.

Running rspec locally this gets rid of the messages (when running ruby 2.7).