### PR TITLE
(PF-2437) Prepend 'Bearer' string to authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,14 @@ resource model are documented on the [Resource Reference][resource_ref] page.
 Each of the models uses ActiveRecord-like REST functionality to map over the Forge API endpoints.
 Most simple ActiveRecord-style interactions function as intended.
 
-Currently, only unauthenticated read-only actions are supported.
+Currently, only read-only actions are supported.
 
 The methods find, where, and all immediately make one API request.
 
 ```ruby
 # Find a Resource by Slug
-PuppetForge::User.find('puppetlabs') # => #<Forge::V3::User(/v3/users/puppetlabs)>
+PuppetForge::User.find('puppetlabs') # => #<PuppetForge::V3::User(/v3/users/puppetlabs)>
+PuppetForge::Module.find('puppetlabs-stdlib') # => #<PuppetForge::V3::Module(/v3/modules/puppetlabs-stdlib)>
 
 # Find All Resources
 PuppetForge::Module.all # See "Paginated Collections" below for important info about enumerating resource sets.
@@ -109,7 +110,7 @@ PuppetForge::Module.where(query: 'apache').all # This method is deprecated and n
 All API Requests (whether via find, where, or all) will raise a Faraday::ResourceNotFound error if the request fails.
 
 
-### Installing a Release
+### Downloading and installing a module release
 
 A release tarball can be downloaded and installed by following the steps below.
 
@@ -185,6 +186,24 @@ user.username # => "puppetlabs"
 # This *does* trigger a request
 user.created_at # => "2010-05-19 05:46:26 -0700"
 ```
+
+### Configuration
+
+To overwrite the default of `https://forgeapi.puppet.com` and set a custom url for the Forge API:
+
+```ruby
+PuppetForge.host = "https://your-own-api.url/"
+```
+
+### Authorization
+
+To authorize your requests with an API key from a Forge user account:
+
+```ruby
+PuppetForge::Connection.authorization = "<your-api-key-here>"
+```
+
+You can generate API keys on your user profile page once you've [logged into the Forge website](https://forge.puppet.com/login).
 
 ### i18n
 

--- a/lib/puppet_forge/connection.rb
+++ b/lib/puppet_forge/connection.rb
@@ -23,6 +23,8 @@ module PuppetForge
 
     attr_writer :conn
 
+    AUTHORIZATION_TOKEN_REGEX = /^[a-f0-9]{64}$/
+
     USER_AGENT = "#{PuppetForge.user_agent} PuppetForge.gem/#{PuppetForge::VERSION} Faraday/#{Faraday::VERSION} Ruby/#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL} (#{RUBY_PLATFORM})".strip
 
     def self.authorization=(token)
@@ -101,7 +103,7 @@ module PuppetForge
       options = { :headers => { :user_agent => USER_AGENT } }.merge(opts)
 
       if token = PuppetForge::Connection.authorization
-        options[:headers][:authorization] = token
+        options[:headers][:authorization] = token =~ AUTHORIZATION_TOKEN_REGEX ? "Bearer #{token}" : token
       end
 
       if lang = PuppetForge::Connection.accept_language

--- a/spec/unit/forge/connection_spec.rb
+++ b/spec/unit/forge/connection_spec.rb
@@ -92,12 +92,41 @@ describe PuppetForge::Connection do
     end
 
     context 'when an authorization value is provided' do
-      before(:each) do
-        allow(described_class).to receive(:authorization).and_return("auth-test value")
+      let(:key) { "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789" }
+      let(:prepended_key) { "Bearer #{key}" }
+
+      context 'when the key already includes the Bearer prefix as expected' do
+        before(:each) do
+          allow(described_class).to receive(:authorization).and_return(prepended_key)
+        end
+
+        it 'does not prepend it again' do
+          expect(subject.headers).to include(:authorization => prepended_key)
+        end
       end
 
-      it 'sets authorization header on requests' do
-        expect(subject.headers).to include(:authorization => "auth-test value")
+      context 'when the key does not includ the Bearer prefix' do
+        context 'when the value looks like a Forge API key' do
+          before(:each) do
+            allow(described_class).to receive(:authorization).and_return(key)
+          end
+
+          it 'prepends "Bearer"' do
+            expect(subject.headers).to include(:authorization => prepended_key)
+          end
+        end
+
+        context 'when the value does not look like a Forge API key' do
+          let(:key) { "auth-test value" }
+
+          before(:each) do
+            allow(described_class).to receive(:authorization).and_return(key)
+          end
+
+          it 'does not alter the value' do
+            expect(subject.headers).to include(:authorization => key)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Authorized requests to the Forge require an authorization header of
"Bearer \<api-key\>". This changes the connection process so that if a
user has set `PuppetForge::Connection.authorization` to something that
looks like a Forge API key (a 64-character hex string), it automatically
prepends the "Bearer " string. This will not take effect if the user
has already prepended "Bearer " themselves, or if the authorization
value doesn't fit the expected key format.

Also updates the README with basic information on authorization.