### PR TITLE
Correct supported Ruby version to >= 2.5

### DIFF
--- a/puppet_forge.gemspec
+++ b/puppet_forge.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.add_runtime_dependency "faraday", "~> 1.3"
   spec.add_runtime_dependency "faraday_middleware", "~> 1.0"


### PR DESCRIPTION
The tests only run on 2.5 and newer, so we should not claim to support
Ruby 2.4.