### PR TITLE
Move to Faraday 2.x, which requires Ruby 2.6+

### DIFF
--- a/.github/workflows/ruby-rspec.yml
+++ b/.github/workflows/ruby-rspec.yml
@@ -22,9 +22,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
 
       - name: Build and test with Rspec
-        run: |
-          gem install bundler
-          bundle install --jobs 4 --retry 3
-          bundle exec rspec
+        run: bundle exec rspec

--- a/.github/workflows/ruby-rspec.yml
+++ b/.github/workflows/ruby-rspec.yml
@@ -14,7 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.7, 2.6, 2.5]
+        ruby:
+          - '3.1'
+          - '3.0'
+          - '2.7'
+          - '2.6'
 
     steps:
       - uses: actions/checkout@v1

--- a/lib/puppet_forge/connection.rb
+++ b/lib/puppet_forge/connection.rb
@@ -1,7 +1,7 @@
 require 'puppet_forge/connection/connection_failure'
 
 require 'faraday'
-require 'faraday_middleware'
+require 'faraday/follow_redirects'
 
 module PuppetForge
   # Provide a common mixin for adding a HTTP connection to classes.
@@ -115,7 +115,7 @@ module PuppetForge
       end
 
       Faraday.new(url, options) do |builder|
-        builder.use FaradayMiddleware::FollowRedirects
+        builder.use Faraday::FollowRedirects::Middleware
         builder.response(:json, :content_type => /\bjson$/, :parser_options => { :symbolize_names => true })
         builder.response(:raise_error)
         builder.use(:connection_failure)

--- a/lib/puppet_forge/connection/connection_failure.rb
+++ b/lib/puppet_forge/connection/connection_failure.rb
@@ -22,4 +22,4 @@ module PuppetForge
   end
 end
 
-Faraday::Middleware.register_middleware(:connection_failure => lambda { PuppetForge::Connection::ConnectionFailure })
+Faraday::Middleware.register_middleware(:connection_failure => PuppetForge::Connection::ConnectionFailure)

--- a/puppet_forge.gemspec
+++ b/puppet_forge.gemspec
@@ -31,8 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "cane"
   spec.add_development_dependency "yard"
   spec.add_development_dependency "redcarpet"
-
-  # Install the right pry debugging combo depending on ruby version.
-  spec.add_development_dependency "pry-debugger" if RUBY_VERSION <= '1.9.3'
-  spec.add_development_dependency "pry-byebug" if RUBY_VERSION >= '2.0.0'
+  spec.add_development_dependency "pry-byebug"
 end

--- a/puppet_forge.gemspec
+++ b/puppet_forge.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.6.0'
 
-  spec.add_runtime_dependency "faraday", "~> 1.3"
-  spec.add_runtime_dependency "faraday_middleware", "~> 1.0"
+  spec.add_runtime_dependency "faraday", "~> 2.0"
+  spec.add_runtime_dependency "faraday-follow_redirects", "~> 0.3.0"
   spec.add_dependency "semantic_puppet", "~> 1.0"
   spec.add_dependency "minitar"
 


### PR DESCRIPTION
It does not attempt to support Faraday 1.x as well because dependency wise it would be impossible to pull in the correct middleware. That is why a hard switch was made.

See individual commits for details.

Replaces https://github.com/puppetlabs/forge-ruby/pull/98, https://github.com/puppetlabs/forge-ruby/pull/97 & https://github.com/puppetlabs/forge-ruby/pull/96.

This would be a major version bump.