### PR TITLE
Allows the user to search by an array of endorsements

### DIFF
--- a/lib/puppet_forge/v3/base.rb
+++ b/lib/puppet_forge/v3/base.rb
@@ -66,6 +66,9 @@ module PuppetForge
             uri_path = "v3/#{resource}/#{item}"
           end
 
+          # The API expects a space separated string. This allows the user to invoke it with a more natural feeling array.
+          params['endorsements'] = params['endorsements'].join(' ') if params['endorsements'].is_a? Array
+
           PuppetForge::V3::Base.conn.get uri_path, params
         end
 


### PR DESCRIPTION
The Forge API expects a space separated list of endorsements. This feels
weird from the perspective of the consumer of a library. I'd expect that
implementation detail to be abstracted away.

This patch allows endorsements to be specified as either the space
separated list or as an array.