### PR TITLE
(CONT-643) Add upload method functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,23 @@ release.verify(Pathname(release_tarball))
 # @raise RuntimeError if it fails to extract the contents of the release tarball
 PuppetForge::Unpacker.unpack(release_tarball, dest_dir, tmp_dir)
 ```
+### Uploading a module release
 
+You can upload new module versions to the forge by following the steps below.
+
+> Note: This API requires authorization. See [Authorization](#authorization) for more information.
+
+```ruby
+release_tarball = 'pkg/puppetlabs-apache-1.6.0.tar.gz'
+
+# Upload a module tarball to the Puppet Forge
+# Returns an instance of V3::Release class and the response from the forge upload 
+# @raise PuppetForge::ReleaseForbidden if a 403 response is recieved from the server
+# @raise PuppetForge::ReleaseBadContent if the module to upload is not valid
+# @raise Faraday::ClientError if any errors encountered in the upload
+# @raise PuppetForge::FileNotFound if the given tarball cannot be found
+release, response = PuppetForge::V3::Release.upload(release_tarball)
+```
 
 ### Paginated Collections
 

--- a/lib/puppet_forge/error.rb
+++ b/lib/puppet_forge/error.rb
@@ -28,16 +28,32 @@ Could not install package
     end
   end
 
+
+  class ErrorWithDetail < PuppetForge::Error
+    def self.from_response(response)
+      body = JSON.parse(response[:body])
+
+      message = body['message']
+      if body.key?('errors') && !body['errors']&.empty?
+        message << "\nThe following errors were returned from the server:\n - #{body['errors'].join("\n - ")}"
+      end
+
+      new(message)
+    end
+  end
+
+  class FileNotFound < PuppetForge::Error
+  end
+
   class ModuleNotFound < PuppetForge::Error
   end
 
   class ReleaseNotFound < PuppetForge::Error
   end
 
-  class ReleaseForbidden < PuppetForge::Error
-    def self.from_response(response)
-      body = JSON.parse(response[:body])
-      new(body["message"])
-    end
+  class ReleaseForbidden < PuppetForge::ErrorWithDetail
+  end
+
+  class ReleaseBadContent < PuppetForge::ErrorWithDetail
   end
 end


### PR DESCRIPTION
The purpose of this change is to introduce upload functionality to the forge ruby client.

We currently push to the forge in pdk but have a custom method for handling it. It would be nice to consolidate and use the client for all forge operations.

The initial commits for this PR were cherry-picked from #65.
