### PR TITLE
Raise ModuleNotFound if a module is not found

### DIFF
--- a/lib/puppet_forge/v3/module.rb
+++ b/lib/puppet_forge/v3/module.rb
@@ -11,6 +11,11 @@ module PuppetForge
       lazy :current_release, 'Release'
       lazy_collection :releases, 'Release'
 
+      def self.find(slug)
+        super
+      rescue Faraday::ResourceNotFound
+        raise PuppetForge::ModuleNotFound, "Module #{slug} not found"
+      end
     end
   end
 end

--- a/spec/unit/forge/v3/module_spec.rb
+++ b/spec/unit/forge/v3/module_spec.rb
@@ -28,8 +28,8 @@ describe PuppetForge::V3::Module do
       expect(mod_stateless.name).to eq('apache')
     end
 
-    it 'returns nil for non-existent modules' do
-      expect { missing_mod }.to raise_error(Faraday::ResourceNotFound)
+    it 'raises exception for non-existent modules' do
+      expect { missing_mod }.to raise_error(PuppetForge::ModuleNotFound, 'Module absent-apache not found')
     end
   end
 


### PR DESCRIPTION
While 026e0c1f467a6edc1e40d3827840fe3b123bef66 did add the exception class, it wasn't used. This avoids leaking an implementation detail.

Technically this is backwards incompatible, since it requires users to change their code. It could make PuppetForge::ModuleNotFound inherit from Faraday::ResourceNotFound, but that stil leaks the implementation detail. It could however be split into two releases: one minor to do this + inherit and make it not inherit in a major release.