### PR TITLE
(PF-2540) Updating README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Or install it yourself as:
 
 ## Requirements
 
-* Ruby >= 1.9.3
+* Ruby >= 2.6.0
 
 ## Dependencies
 
-* [Faraday]() >= 0.9.0 < 0.14.0
+* [Faraday]() 2.x
 * [Typhoeus](https://github.com/typhoeus/typhoeus) ~> 1.0.1 (optional)
 
 Typhoeus will be used as the HTTP adapter if it is available, otherwise


### PR DESCRIPTION
This PR was originally to drop support for Ruby 2.4, but most of that was already covered in this PR: https://github.com/puppetlabs/forge-ruby/pull/99. After speaking with Jesse, I made a few small changes to the README that were previously overlooked in that PR.