### PR TITLE
Make Digest subclass lookup thread-safe in lru_cache

### DIFF
--- a/lib/puppet_forge/lru_cache.rb
+++ b/lib/puppet_forge/lru_cache.rb
@@ -9,7 +9,7 @@ module PuppetForge
     # a convenience method for generating cache keys. Cache keys do not
     # have to be SHA256 hashes, but they must be unique.
     def self.new_key(*string_args)
-      Digest::SHA256.hexdigest(string_args.map(&:to_s).join(':'))
+      Digest(:SHA256).hexdigest(string_args.map(&:to_s).join(':'))
     end
 
     # @return [Integer] the maximum number of items to cache.


### PR DESCRIPTION
r10k content_synchronizer uses Forge v3 API when installing a module: https://github.com/puppetlabs/r10k/blob/4.0.0/lib/r10k/module/forge.rb#L95 https://github.com/puppetlabs/r10k/blob/4.0.0/lib/r10k/module/forge.rb#L128 https://github.com/puppetlabs/r10k/blob/4.0.0/lib/r10k/module/forge.rb#L176

r10k uses a thread pool to install the modules, therefore the Forge v3 API calls have to be thread safe, and so does the LruCache class used to cache API responses.

If LruCache is left not thread safe, the same error as reported in r10k issue #979 happens.
https://github.com/puppetlabs/r10k/issues/979