### PR TITLE
Pin minitar version to < 1.0.0 to keep project working

### DIFF
--- a/puppet_forge.gemspec
+++ b/puppet_forge.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "faraday", "~> 2.0"
   spec.add_runtime_dependency "faraday-follow_redirects", "~> 0.3.0"
   spec.add_dependency "semantic_puppet", "~> 1.0"
-  spec.add_dependency "minitar"
+  spec.add_dependency "minitar", "< 1.0.0 "
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
## Summary
minitar recently released their v1 release, containing some breaking changes. When using this package (or `librarian-puppet`, which depends on it) I get this:
```
$ gem install --no-document librarian-puppet -v '~> 5'
Fetching librarian-puppet-5.0.0.gem
Fetching rsync-1.0.9.gem
Fetching minitar-1.0.1.gem
Fetching faraday-2.10.1.gem
Fetching faraday-net_http-3.1.1.gem
Fetching faraday-follow_redirects-0.3.0.gem
Fetching puppet_forge-4.1.0.gem
Fetching librarianp-1.1.2.gem
Successfully installed rsync-1.0.9
Successfully installed minitar-1.0.1
Successfully installed faraday-net_http-3.1.1
Successfully installed faraday-2.10.1
Successfully installed faraday-follow_redirects-0.3.0
Successfully installed puppet_forge-4.1.0
Successfully installed librarianp-1.1.2
Successfully installed librarian-puppet-5.0.0
8 gems installed

$ librarian-puppet install --clean
<internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require': cannot load such file -- archive/tar/minitar (LoadError)
	from <internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/puppet_forge-4.1.0/lib/puppet_forge/tar/mini.rb:2:in `<top (required)>'
	from <internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from <internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/puppet_forge-4.1.0/lib/puppet_forge/tar.rb:4:in `<class:Tar>'
	from /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/puppet_forge-4.1.0/lib/puppet_forge/tar.rb:3:in `<module:PuppetForge>'
	from /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/puppet_forge-4.1.0/lib/puppet_forge/tar.rb:2:in `<top (required)>'
	from <internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from <internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/puppet_forge-4.1.0/lib/puppet_forge.rb:21:in `<module:PuppetForge>'
	from /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/puppet_forge-4.1.0/lib/puppet_forge.rb:3:in `<top (required)>'
	from <internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from <internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/librarian-puppet-5.0.0/lib/librarian/puppet/source/forge/repo_v3.rb:2:in `<top (required)>'
	from <internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from <internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/librarian-puppet-5.0.0/lib/librarian/puppet/source/forge.rb:4:in `<top (required)>'
	from <internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from <internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/librarian-puppet-5.0.0/lib/librarian/puppet/source.rb:3:in `<top (required)>'
	from <internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from <internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/librarian-puppet-5.0.0/lib/librarian/puppet/dsl.rb:3:in `<top (required)>'
	from <internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from <internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/librarian-puppet-5.0.0/lib/librarian/puppet/environment.rb:2:in `<top (required)>'
	from <internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from <internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/librarian-puppet-5.0.0/lib/librarian/puppet/extension.rb:1:in `<top (required)>'
	from <internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from <internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/librarian-puppet-5.0.0/lib/librarian/puppet.rb:4:in `<top (required)>'
	from <internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from <internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/librarian-puppet-5.0.0/lib/librarian/puppet/cli.rb:4:in `<top (required)>'
	from <internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from <internal:/opt/puppetlabs/puppet/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from /opt/puppetlabs/puppet/lib/ruby/gems/3.2.0/gems/librarian-puppet-5.0.0/bin/librarian-puppet:6:in `<top (required)>'
	from /opt/puppetlabs/puppet/bin/librarian-puppet:25:in `load'
	from /opt/puppetlabs/puppet/bin/librarian-puppet:25:in `<main>'
```

This sounds very similar to https://github.com/halostatue/minitar/issues/61 where someone explained that the `archive/tar/minitar` namespace is not present anymore. So either the version is pinned to < 1.0 or someone fixes the minitar implementation to make it work with newer releases as well.
